### PR TITLE
favor DEPLOY_REPO but use REPO as a fallback

### DIFF
--- a/src/release.sh
+++ b/src/release.sh
@@ -33,7 +33,7 @@ fi
 git init
 git config --global user.name $COMMIT_AUTHOR_USERNAME
 git config --global user.email $COMMIT_AUTHOR_EMAIL
-git remote add travis-build ${REPO}.git
+git remote add travis-build ${DEPLOY_REPO:-$REPO}.git
 git add .
 git commit -m "${TRAVIS_COMMIT_MESSAGE}"
 git push --force --set-upstream travis-build HEAD:$1


### PR DESCRIPTION
Changes the env name of the target deploy repo to DEPLOY_REPO
For some time fall back to REPO if DEPLOY_REPO is unset