### PR TITLE
Add a nightly build script

### DIFF
--- a/src/after_success.sh
+++ b/src/after_success.sh
@@ -34,3 +34,9 @@ else
         .travis/release.sh "${TRAVIS_BRANCH}"
     fi
 fi
+
+# Ignore custom release so we can build repo nightly
+if [ "${TRAVIS_BRANCH}" = "nightly" ]; then
+    .travis/nightly.sh
+    .travis/release.sh "nightly"
+fi

--- a/src/bootstrap.sh
+++ b/src/bootstrap.sh
@@ -4,6 +4,7 @@ set -x
 
 COMMON_URL="https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/"
 CHROME_URL="https://raw.githubusercontent.com/RedHatInsights/insights-chrome/master/"
+curl $COMMON_URL/src/nightly.sh > .travis/nightly.sh
 curl $COMMON_URL/src/after_success.sh > .travis/after_success.sh
 curl $COMMON_URL/src/release.sh > .travis/release.sh
 curl $COMMON_URL/src/Jenkinsfile > .travis/58231b16fdee45a03a4ee3cf94a9f2c3

--- a/src/nightly.sh
+++ b/src/nightly.sh
@@ -1,0 +1,27 @@
+#!/usr/bash/env bash
+set -e
+set -x
+
+# Rest branch to master so cron job takes care of all the work
+git reset --hard master
+
+# install packages
+npm install @patternfly/patternfly@latest
+npm install @patternfly/react-core@prerelease
+npm install @patternfly/react-tokens@prerelease
+npm install @patternfly/react-icons@latest
+npm install @patternfly/react-charts@prerelease
+
+# Echo version numbers for deugging
+echo "using @patternfly/patternfly version " npm show @patternfly/patternfly version
+echo "using @patternfly/react-core version " npm show @patternfly/react-core version
+echo "using @patternfly/react-tokens version " npm show @patternfly/react-tokens version
+echo "using @patternfly/react-icons " npm show @patternfly/react-icons version
+echo "using @patternfly/react-charts " npm show @patternfly/react-charts version
+
+# Lint + Test
+npm run lint
+npm run test
+
+# build it
+NODE_ENV=production webpack --config config/prod.webpack.config.js


### PR DESCRIPTION
I think this may be an approach we want to take. Essentially, we can set up travis to do a cron job on a certain branch (`nightly` in this case) and then it should rebuild and deploy it to a `nightly` environment.