### PR TITLE
update nightly to actually get the most recent version of master

### DIFF
--- a/src/nightly.sh
+++ b/src/nightly.sh
@@ -6,9 +6,6 @@ set -x
 git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
 git remote update
 
-# see branches
-git branch -a
-
 # Rest branch to master so cron job takes care of all the work
 git reset --hard remotes/origin/master
 


### PR DESCRIPTION
Slammed some stuff into master, but travis only actually clones one branch, so I need to make sure I add the remote correctly and then update it so that we can pull down all the branches. This will allow the nightly build to always pick up the latest changes on master.