### PR TITLE
switch to eccu based cache busting (actually works)

### DIFF
--- a/src/akamai_cache_buster/bustCache.py
+++ b/src/akamai_cache_buster/bustCache.py
@@ -92,10 +92,7 @@ def main():
             ]
         }
 
-        print(body)
-        print(base_url + "/eccu/v1/requests")
-        #print(akamaiPost("/ccu/v3/invalidate/url/staging", body))
-        #print(akamaiPost("/eccu-api/v1/requests", body))
+        print(akamaiPost("/eccu-api/v1/requests", body))
 
 if __name__ == "__main__":
     main()

--- a/src/akamai_cache_buster/bustCache.py
+++ b/src/akamai_cache_buster/bustCache.py
@@ -60,23 +60,6 @@ def main():
     paths = getYMLFromUrl("https://cloud.redhat.com/config/main.yml").get(appName).get("frontend").get("paths")
     for path in paths:
         print(path.split('/'))
-    #print(paths)
-
-    #  old way
-    # urls = []
-    # for paths in getYMLFromUrl("https://cloud.redhat.com/config/main.yml").get(appName).get("frontend").get("paths"):
-    #     urls.append("https://cloud.redhat.com" + paths)
-    #     for subApps in getYMLFromUrl("https://cloud.redhat.com/config/main.yml").get(appName).get("frontend").get("sub_apps"):
-    #         urls.append("https://cloud.redhat.com" + paths + "/" + subApps.get("id"))
-    
-    # for url in urls:
-    #     print(url)
-
-    # body = {
-    #     "objects" : urls
-    # }
-
-    #generate metadata xml
    
     #create a request for each path
     for path in paths:

--- a/src/akamai_cache_buster/bustCache.py
+++ b/src/akamai_cache_buster/bustCache.py
@@ -63,14 +63,14 @@ def createMetadata(path):
 
     return metadata
 
-def createRequest(path):
+def createRequest(path, appName):
     body = {
         "propertyName": "cloud.redhat.com",
         "propertyNameExactMatch": 'true',
         "propertyType": "HOST_HEADER",
         "metadata": createMetadata(path),
         "notes": "purging cache for new deployment",
-        "requestName": "Invalidate cache for some frontend",
+        "requestName": f"Invalidate cache for {appName}",
         "statusUpdateEmails": [
             "rfelton@redhat.com"
         ]
@@ -88,7 +88,7 @@ def main():
     #create a request for each path
     paths = getYMLFromUrl("https://cloud.redhat.com/config/main.yml").get(appName).get("frontend").get("paths")
     for path in paths:
-        akamaiPost("/eccu-api/v1/requests", createRequest(path))
+        akamaiPost("/eccu-api/v1/requests", createRequest(path, appName))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This script will clear the cache for everything under the paths for a specific app (so long as it has paths listed in the source of truth). 

to run: python3 bustCache.py /path/to/edgerc nameOfApp

A few more notes:
- your edgerc needs read/write permision for the eccu API on akamai (not open CCU)
- only works on production akamai
- requests take about 30 minutes to finish, right now I am the only one emailed when it finished, we should send this to a mailing list of frontend devs in the future
- will not work on apps that don't have paths listed in source of truth, also not super friendly about errors at the moment