### PR TITLE
enable cache purge for all apps

### DIFF
--- a/src/Jenkinsfile
+++ b/src/Jenkinsfile
@@ -46,21 +46,19 @@ node {
          """
       }
 
-      //run on a node with python on it
-      if (APP_NAME == "storybook") {
-        openShift.withNode(image: "docker-registry.default.svc:5000/jenkins/jenkins-slave-base-centos7-python36:latest") {
-          //install python dependencies
-          sh "curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py"
-          sh "python3 get-pip.py --user"
-          sh "wget https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/akamai_cache_buster/bustCache.py"
-          sh "wget https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/akamai_cache_buster/requirements.txt"
-          sh "python3 -m pip install --user -r requirements.txt"
-          sh "export PATH=$PATH:/home/jenkins/.local/bin"
-          withCredentials([file(credentialsId: "rhcs-purge-edgerc", variable: 'EDGERC')]) {
-            //path to .edgerc file is now set to $EDGERC"
-            //Bust the current cache
-            sh "python3 bustCache.py $EDGERC ${APP_NAME}"
-          }
+      //Clear the cache for the app being deployed
+      openShift.withNode(image: "docker-registry.default.svc:5000/jenkins/jenkins-slave-base-centos7-python36:latest") {
+        //install python dependencies
+        sh "curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py"
+        sh "python3 get-pip.py --user"
+        sh "wget https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/akamai_cache_buster/bustCache.py"
+        sh "wget https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/akamai_cache_buster/requirements.txt"
+        sh "python3 -m pip install --user -r requirements.txt"
+        sh "export PATH=$PATH:/home/jenkins/.local/bin"
+        withCredentials([file(credentialsId: "rhcs-purge-edgerc", variable: 'EDGERC')]) {
+          //path to .edgerc file is now set to $EDGERC"
+          //Bust the current cache
+          sh "python3 bustCache.py $EDGERC ${APP_NAME}"
         }
       }
     }


### PR DESCRIPTION
Switches from only running the cache buster on storybook deployments to running for all deployments. Not to be merged until we confirm it's working okay on storybook