### PR TITLE
Add pf-dependnecies to app.info.json file.

### DIFF
--- a/src/release.sh
+++ b/src/release.sh
@@ -13,6 +13,13 @@ NPM_INFO="undefined"
 
 # instead of using -v use -n to check for an empty strings
 # -v is not working well on bash 3.2 on osx
+PATTERNFLY_DEPS="undefined"
+if [[ -f package-lock.json ]];
+then
+  LINES=`npm list --silent --depth=0 --production | grep @patternfly -i | sed -E "s/^(.{0})(.{4})/\1/" | tr "\n" "," | sed -E "s/,/\",\"/g"` 
+  PATTERNFLY_DEPS="[\"${LINES%???}\"]"
+fi
+
 if [[ -n "$APP_BUILD_DIR" &&  -d $APP_BUILD_DIR ]]
 then
     cd $APP_BUILD_DIR
@@ -27,6 +34,7 @@ echo "{
   \"src_hash\": \"$SRC_HASH\",
   \"src_tag\": \"$TRAVIS_TAG\",
   \"src_branch\": \"$TRAVIS_BRANCH\",
+  \"patternfly_dependencies\": $PATTERNFLY_DEPS
   \"travis\": {
     \"event_type\": \"$TRAVIS_EVENT_TYPE\",
     \"build_number\": \"$TRAVIS_BUILD_NUMBER\",


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-7916

This script adds a new key to the info file with an array of PF dependencies. The output looks likes this:
```
 "patternfly_dependencies": ["@patternfly/react-core@4.47.0","@patternfly/react-icons@4.7.4","@patternfly/react-styles@4.7.3","@patternfly/react-table@4.16.7"]
```

It only looks for direct production dependencies.