### PR TITLE
consider 'main' branch into condition while releasing

### DIFF
--- a/src/after_success.sh
+++ b/src/after_success.sh
@@ -25,7 +25,7 @@ then
     .travis/custom_release.sh
 else
     # If current dev branch is master, push to build repo ci-beta
-    if [ "${TRAVIS_BRANCH}" = "master" ]; then
+    if [[ "${TRAVIS_BRANCH}" = "master" ||  "${TRAVIS_BRANCH}" = "main" ]]; then
         .travis/release.sh "ci-beta"
     fi
 


### PR DESCRIPTION
 As for new github repository, it creates `main` branch as default branch.
 It will be helpful to have both default branches in existing script.