### PR TITLE
Update cache busting

### DIFF
--- a/src/akamai_cache_buster/bustCache.py
+++ b/src/akamai_cache_buster/bustCache.py
@@ -56,6 +56,11 @@ def createMetadata(paths, releases, appName):
         prefix = releases[key].get("content_path_prefix")
         if (prefix == None):
             prefix = ''
+        
+        splitPrefix f"apps"
+        metadata += f'<match:recursive-dirs value=\"apps/{prefix + '/'}{appName}\">\n'
+        metadata += '<revalidate>now</revalidate>'
+        metadata += '</match:recursive-dirs>'
         for path in paths:
             path = prefix + path
             splitPath = path.split('/')
@@ -67,10 +72,6 @@ def createMetadata(paths, releases, appName):
                 metadataClosingTags += '   ' * (pathLength - i) + '</match:recursive-dirs>\n'
             metadata += '   ' * pathLength + '<revalidate>now</revalidate>\n'
             metadata += metadataClosingTags
-
-    metadata += f'<match:recursive-dirs value=\"apps/{appName}\">\n'
-    metadata += '<revalidate>now</revalidate>'
-    metadata += '</match:recursive-dirs>'
     metadata += '</eccu>'
 
     return metadata

--- a/src/akamai_cache_buster/bustCache.py
+++ b/src/akamai_cache_buster/bustCache.py
@@ -97,12 +97,12 @@ def main():
 
     #get the data to use for cache busting
     try:
-        paths = getYMLFromUrl("https://cloud.redhat.com/config/main.yml").get(appName).get("frontend").get("paths")
+        paths = getYMLFromUrl("https://console.redhat.com/config/main.yml").get(appName).get("frontend").get("paths")
     except:
         print("WARNING: this app has no path, if that's okay ignore this :)")
         return
 
-    releases = getYMLFromUrl("https://cloud.redhat.com/config/releases.yml")
+    releases = getYMLFromUrl("https://console.redhat.com/config/releases.yml")
 
     akamaiPost("/eccu-api/v1/requests", createRequest(paths, releases, appName))
 

--- a/src/akamai_cache_buster/bustCache.py
+++ b/src/akamai_cache_buster/bustCache.py
@@ -99,11 +99,12 @@ def main():
     initEdgeGridAuth()
 
     #get the data to use for cache busting
+    paths
     try:
         paths = getYMLFromUrl("https://console.redhat.com/config/main.yml").get(appName).get("frontend").get("paths")
     except:
         print("WARNING: this app has no path, if that's okay ignore this :)")
-        return
+        paths = []
 
     releases = getYMLFromUrl("https://console.redhat.com/config/releases.yml")
 

--- a/src/akamai_cache_buster/bustCache.py
+++ b/src/akamai_cache_buster/bustCache.py
@@ -53,7 +53,7 @@ def createMetadata(paths, releases, appName):
 
     #generate the paths XML
     for key in releases:
-        prefix = releases[key].get("prefix")
+        prefix = releases[key].get("content_path_prefix")
         if (prefix == None):
             prefix = ''
         for path in paths:

--- a/src/akamai_cache_buster/bustCache.py
+++ b/src/akamai_cache_buster/bustCache.py
@@ -47,7 +47,7 @@ base_url = "https://" + getHostFromConfig()
 
 #uses the paths for the app and the environments it's released on to generate
 #the XML used in the API request
-def createMetadata(paths, releases):
+def createMetadata(paths, releases, appName):
     #Add the begining XML
     metadata = '<?xml version=\"1.0\"?>\n<!-- Submitted by bustCache.py script automatically -->\n<eccu>\n'
 
@@ -68,6 +68,9 @@ def createMetadata(paths, releases):
             metadata += '   ' * pathLength + '<revalidate>now</revalidate>\n'
             metadata += metadataClosingTags
 
+    metadata += f'<match:recursive-dirs value=\"apps/{appName}\">\n'
+    metadata += '<revalidate>now</revalidate>'
+    metadata += '</match:recursive-dirs>'
     metadata += '</eccu>'
 
     return metadata
@@ -77,7 +80,7 @@ def createRequest(paths, releases, appName):
         "propertyName": "cloud.redhat.com",
         "propertyNameExactMatch": 'true',
         "propertyType": "HOST_HEADER",
-        "metadata": createMetadata(paths, releases),
+        "metadata": createMetadata(paths, releases, appName),
         "notes": "purging cache for new deployment",
         "requestName": f"Invalidate cache for {appName}",
         "statusUpdateEmails": [


### PR DESCRIPTION
possible fix for: https://issues.redhat.com/browse/RHCLOUD-15557

### Changes
- update yml endpoints to use console.redhat.com
- add apps/appName revalidate rule
- allow empty paths attribute as it is no longer required

Currently the script sends request to bust only these resources:
```XML
<match:recursive-dirs value="cost-management">
	<revalidate>now</revalidate>
</match:recursive-dirs>
```

If the `apps/` prefix is not automatically added (which i doubt), this would mean, that it only revalidates the `HTML` templates and never any other static assets. This would be probably the reason why we had to introduce JS hashes in the first place.

Also, from the script, I would assume the payload should also have rules for `/beta` assets, but it does not have them. The have the same rule 4x in the payload. My assumption is based on the `releases.yml` content:
```yml
Stable:
  branch: prod-stable

Beta:
  branch: prod-beta
  url_prefix: /beta
  content_path_prefix: /beta

PenTestStable:
  branch: qa-stable
  cookie_required: True
  content_path_prefix: /pentest

PenTestBeta:
  branch: qa-beta
  cookie_required: True
  url_prefix: /beta
  content_path_prefix: /pentest/beta
```

We have 4 different envs. 3 of them have prefixes but they are never applied to any rule, even though they are supposed to be:
```python
    for key in releases:
        prefix = releases[key].get("prefix")
        if (prefix == None):
            prefix = ''
        for path in paths:
            path = prefix + path
```

This is the payload that was generated in my local env:
```xml
<?xml version="1.0"?>\n
<!-- Submitted by bustCache.py script automatically -->\n
<eccu>
	<match:recursive-dirs value="cost-management"> 
		<revalidate>now</revalidate>
	</match:recursive-dirs>
	<match:recursive-dirs value="openshift">
		<match:recursive-dirs value="cost-management">         
			<revalidate>now</revalidate>
		</match:recursive-dirs>
	</match:recursive-dirs>
	<match:recursive-dirs value="cost-management"> 
		<revalidate>now</revalidate>
	</match:recursive-dirs>
	<match:recursive-dirs value="openshift">
		<match:recursive-dirs value="cost-management">         
			<revalidate>now</revalidate>
		</match:recursive-dirs>
	</match:recursive-dirs>
	<match:recursive-dirs value="cost-management"> 
		<revalidate>now</revalidate>
	</match:recursive-dirs>
	<match:recursive-dirs value="openshift">
		<match:recursive-dirs value="cost-management">
			<revalidate>now</revalidate>
		</match:recursive-dirs>
	</match:recursive-dirs>
	<match:recursive-dirs value="cost-management">\n      
		<revalidate>now</revalidate>
	</match:recursive-dirs>
	<match:recursive-dirs value="openshift">
		<match:recursive-dirs value="cost-management">         
			<revalidate>now</revalidate>
		</match:recursive-dirs>
	</match:recursive-dirs>
</eccu>
```

I believe this is what we need. New changes will generate is following XML:
```XML
<?xml version="1.0"?>
<!-- Submitted by bustCache.py script automatically -->
<eccu>
	<match:recursive-dirs value="apps">   
		<match:recursive-dirs value="cost-management">      
			<revalidate>now</revalidate>         
		</match:recursive-dirs>      
	</match:recursive-dirs>   
	<match:recursive-dirs value="cost-management">      
		<revalidate>now</revalidate>   
	</match:recursive-dirs>   
	<match:recursive-dirs value="openshift">      
		<match:recursive-dirs value="cost-management">         
			<revalidate>now</revalidate>      
		</match:recursive-dirs>   
	</match:recursive-dirs>
	<match:recursive-dirs value="apps">   
		<match:recursive-dirs value="beta">      
			<match:recursive-dirs value="cost-management">         
				<revalidate>now</revalidate>            
			</match:recursive-dirs>         
		</match:recursive-dirs>      
	</match:recursive-dirs>   
	<match:recursive-dirs value="beta">      
		<match:recursive-dirs value="cost-management">         
			<revalidate>now</revalidate>      
		</match:recursive-dirs>   
	</match:recursive-dirs>   
	<match:recursive-dirs value="beta">      
		<match:recursive-dirs value="openshift">         
			<match:recursive-dirs value="cost-management">            
				<revalidate>now</revalidate>         
			</match:recursive-dirs>      
		</match:recursive-dirs>   
	</match:recursive-dirs>
	<match:recursive-dirs value="apps">   
		<match:recursive-dirs value="pentest">      
			<match:recursive-dirs value="cost-management">         
				<revalidate>now</revalidate>            
			</match:recursive-dirs>         
		</match:recursive-dirs>      
	</match:recursive-dirs>   
	<match:recursive-dirs value="pentest">      
		<match:recursive-dirs value="cost-management">         
			<revalidate>now</revalidate>      
		</match:recursive-dirs>   
	</match:recursive-dirs>   
	<match:recursive-dirs value="pentest">      
		<match:recursive-dirs value="openshift">         
			<match:recursive-dirs value="cost-management">            
				<revalidate>now</revalidate>         
			</match:recursive-dirs>      
		</match:recursive-dirs>   
	</match:recursive-dirs>
	<match:recursive-dirs value="apps">   
		<match:recursive-dirs value="pentest">      
			<match:recursive-dirs value="beta">         
				<match:recursive-dirs value="cost-management">            
					<revalidate>now</revalidate>               
				</match:recursive-dirs>            
			</match:recursive-dirs>         
		</match:recursive-dirs>      
	</match:recursive-dirs>   
	<match:recursive-dirs value="pentest">      
		<match:recursive-dirs value="beta">         
			<match:recursive-dirs value="cost-management">            
				<revalidate>now</revalidate>         
			</match:recursive-dirs>      
		</match:recursive-dirs>   
	</match:recursive-dirs>   
	<match:recursive-dirs value="pentest">      
		<match:recursive-dirs value="beta">         
			<match:recursive-dirs value="openshift">            
				<match:recursive-dirs value="cost-management">               
					<revalidate>now</revalidate>            
				</match:recursive-dirs>         
			</match:recursive-dirs>      
		</match:recursive-dirs>   
	</match:recursive-dirs>
</eccu>
```

As this is the first time I see this script I would appreciate if somebody could confirm/disprove the above.

### TO DO?
- the script may not consider `/beta` namespace?
- do we have to bust `/apps/<app-name>` directory?

cc @astrozzc