### PR TITLE
Adjust generation of nginx and app info

### DIFF
--- a/src/nginx_conf_gen.sh
+++ b/src/nginx_conf_gen.sh
@@ -36,33 +36,26 @@ FROM registry.access.redhat.com/ubi8/nginx-118
 
 COPY ./nginx.conf /opt/app-root/etc/nginx/conf.d/default.conf
 COPY . /opt/app-root/src
-ADD ./nginx.conf "${NGINX_CONFIGURATION_PATH}"
+ADD ./nginx.conf "\${NGINX_CONFIGURATION_PATH}"
 
 CMD ["nginx", "-g", "daemon off;"]
 EOF
 }
 
-if [[ -f package-lock.json ]] || [[ -f yarn.lock ]];
-then
-  LINES=`npm list --silent --depth=0 --production | grep @patternfly -i | sed -E "s/^(.{0})(.{4})/\1/" | tr "\n" "," | sed -E "s/,/\",\"/g"`
-  PATTERNFLY_DEPS="[\"${LINES%???}\"]"
-else PATTERNFLY_DEPS="[]"
-fi
+function generate_app_info() {
+  if [[ -f package-lock.json ]] || [[ -f yarn.lock ]];
+  then
+    LINES=`npm list --silent --depth=0 --production | grep @patternfly -i | sed -E "s/^(.{0})(.{4})/\1/" | tr "\n" "," | sed -E "s/,/\",\"/g"`
+    PATTERNFLY_DEPS="[\"${LINES%???}\"]"
+  else PATTERNFLY_DEPS="[]"
+  fi
 
-if [[ -n "$APP_BUILD_DIR" &&  -d $APP_BUILD_DIR ]]
-then
-    cd $APP_BUILD_DIR
-else
-    cd dist || cd build
-fi
-
-echo $NPM_INFO > ./app.info.deps.json
-
-echo "{
-  \"app_name\": \"$APP_NAME\",
-  \"src_hash\": \"$GIT_COMMIT\",
-  \"patternfly_dependencies\": $PATTERNFLY_DEPS,
-}" > $APP_ROOT/app.info.json
+  echo "{
+    \"app_name\": \"$APP_NAME\",
+    \"src_hash\": \"$GIT_COMMIT\",
+    \"patternfly_dependencies\": $PATTERNFLY_DEPS,
+  }" > ./app.info.json
+}
 
 if [[ -f $APP_ROOT/nginx.conf ]]; then
   echo "nginx config already exists, skipping generation"
@@ -76,3 +69,23 @@ else
   generate_dockerfile
 fi
 
+# Generate app info and app info deps
+
+if [[ -n "$APP_BUILD_DIR" &&  -d $APP_BUILD_DIR ]]
+then
+    cd $APP_BUILD_DIR
+else
+    cd dist || cd build
+fi
+
+if [[ -f ./app.info.deps.json ]]; then
+  echo "app.info.deps.json already exists, skipping generation"
+else
+  echo $NPM_INFO > ./app.info.deps.json
+fi
+
+if [[ -f ./app.info.json ]]; then
+  echo "app.info.json already exists, skipping generation"
+else
+  generate_app_info()
+fi

--- a/src/nginx_conf_gen.sh
+++ b/src/nginx_conf_gen.sh
@@ -47,13 +47,18 @@ function generate_app_info() {
   then
     LINES=`npm list --silent --depth=0 --production | grep @patternfly -i | sed -E "s/^(.{0})(.{4})/\1/" | tr "\n" "," | sed -E "s/,/\",\"/g"`
     PATTERNFLY_DEPS="[\"${LINES%???}\"]"
-  else PATTERNFLY_DEPS="[]"
+    LINES=`npm list --silent --depth=0 --production | grep @redhat-cloud-services -i | sed -E "s/^(.{0})(.{4})/\1/" | tr "\n" "," | sed -E "s/,/\",\"/g"`
+    RH_CLOUD_SERVICES_DEPS="[\"${LINES%???}\"]"
+  else
+    PATTERNFLY_DEPS="[]"
+    RH_CLOUD_SERVICES_DEPS="[]"
   fi
 
   echo "{
     \"app_name\": \"$APP_NAME\",
     \"src_hash\": \"$GIT_COMMIT\",
     \"patternfly_dependencies\": $PATTERNFLY_DEPS,
+    \"rh_cloud_services_dependencies\": $RH_CLOUD_SERVICES_DEPS
   }" > ./app.info.json
 }
 


### PR DESCRIPTION
### Docker file config adjustments

Since we want to fully utilize nginx config in Docker, we have to escape `NGINX_CONFIGURATION_PATH` in orfer to preserve it for docker generation.

### App info generation

When running this script the app info can already be generated, so let's check if these files exists in dist folder. If so let's not re-create them.