### PR TITLE
USE either APP_ROOT or pwd in quay push

### DIFF
--- a/src/quay_push.sh
+++ b/src/quay_push.sh
@@ -3,7 +3,7 @@
 # IMAGE, IMAGE_TAG, and Tokens are exported from upstream pr_check.sh
 export LC_ALL=en_US.utf-8
 export LANG=en_US.utf-8
-export APP_ROOT=$(pwd)
+export APP_ROOT=${APP_ROOT:-pwd}
 export WORKSPACE=${WORKSPACE:-$APP_ROOT}  # if running in jenkins, use the build's workspace
 export IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 export GIT_COMMIT=$(git rev-parse HEAD)


### PR DESCRIPTION
Since hac-core dockerfile and nginx is at root, but the source code folder is located in `frontend` let's use `APP_ROOT` when building image.