### PR TITLE
Fix IS_PR label for main branch builds

### DIFF
--- a/src/frontend-build.sh
+++ b/src/frontend-build.sh
@@ -18,7 +18,7 @@ trap "teardown_docker" EXIT SIGINT SIGTERM
 
 # Job name will container pr-check or build-master. $GIT_BRANCH is not populated on a
 # manually triggered build
-if echo $JOB_NAME | grep -w "build-master" > /dev/null; then
+if echo $JOB_NAME | grep -w "build-master" > /dev/null || echo $JOB_NAME | grep -w "build-main" > /dev/null; then
   CONTAINER_NAME="$APP_NAME-build-main"
   IS_PR=false
 fi


### PR DESCRIPTION
Currently, the automation only tracks on build-master, but we also need to support build-main.