### PR TITLE
Update after_succes scripts not to push to ci and qa envs

### DIFF
--- a/src/after_success.sh
+++ b/src/after_success.sh
@@ -24,13 +24,13 @@ if [ -x .travis/custom_release.sh ]
 then
     .travis/custom_release.sh
 else
-    # If current dev branch is master, push to build repo ci-beta
+    # If current dev branch is master, push to build repo stage-beta
     if [[ "${TRAVIS_BRANCH}" = "master" ||  "${TRAVIS_BRANCH}" = "main" ]]; then
-        .travis/release.sh "ci-beta"
+        .travis/release.sh "stage-beta"
     fi
 
     # If current dev branch is deployment branch, push to build repo
-    if [[ "${TRAVIS_BRANCH}" = "ci-stable" || "${TRAVIS_BRANCH}" = "qa-beta" || "${TRAVIS_BRANCH}" = "qa-stable" || "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" || "${TRAVIS_BRANCH}" = "qaprodauth-stable" || "${TRAVIS_BRANCH}" = "qaprodauth-beta" || "${TRAVIS_BRANCH}" = "stage-beta" || "${TRAVIS_BRANCH}" = "stage-stable" ]]; then
+    if [[ "${TRAVIS_BRANCH}" = "stage-stable" || "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" || "${TRAVIS_BRANCH}" = "qaprodauth-stable" || "${TRAVIS_BRANCH}" = "qaprodauth-beta" ]]; then
         .travis/release.sh "${TRAVIS_BRANCH}"
     fi
 fi


### PR DESCRIPTION
This PR is intended to remove ci and qa environments from build pipeline. I am not sure the scope of applications using this script, but for insights applications, current standard is to use stage environments instead of ci and qa. Let me know if there is something needs to be improved.

Why I creatd this PR:
After upgrading deps in Patch application, master was failing to auto pushed to ci and qa environments. I had to write a custom_release.sh script to fix this. This has happened for Vulnerability and Inventory apps as well.