### PR TITLE
Send slack notification after deploy instead of before

### DIFF
--- a/src/Jenkinsfile
+++ b/src/Jenkinsfile
@@ -33,10 +33,6 @@ node {
       app_info.build_id = env.BUILD_ID
       writeJSON file: "./app.info.json", json: app_info
 
-      // Send Slack Notification
-      String SLACK_TEXT = "${APP_NAME}/${BRANCH} [STATUS] - Deploy build ${app_info.build_id} started for GIT COMMIT ${app_info.build_hash}."
-      slackSend message: SLACK_TEXT, color: 'black', channel: '#insights-bots'
-
       AKAMAI_BASE_PATH = "822386"
       AKAMAI_APP_PATH = "/${AKAMAI_BASE_PATH}/${PREFIX}apps/${APP_NAME}"
 
@@ -71,6 +67,10 @@ node {
           sh "python3 bustCache.py $EDGERC ${APP_NAME} ${BRANCH}"
         }
       }
+
+      // Send Slack Notification
+      String SLACK_TEXT = "${APP_NAME}/${BRANCH} [STATUS] - Deploy build ${app_info.build_id} finished for GIT COMMIT ${app_info.build_hash}."
+      slackSend message: SLACK_TEXT, color: 'black', channel: '#insights-bots'
     }
   }
 }


### PR DESCRIPTION
Currently [seeing error](https://insights-dev-jenkins.apps.crcd01ue1.zmsj.p1.openshiftapps.com/job/insights-frontend-deployer/job/uhc-portal-frontend-deploy/job/prod-stable/67/console), which prevents deployment from proceeding:

    java.lang.NoSuchMethodError: No such DSL method 'slackSend' found among steps [_OcAction, _OcContextInit, _OcWatch, ansiColor, archive, bat, build, catchError, checkout, compareVersions, container, containerLog, deleteDir, dir, echo, envVarsForTool, error, fileExists, findFiles, getContext, git, input, isUnix, jiraComment, jiraIssueSelector, jiraSearch, junit, library, libraryResource, load, lock, mail, milestone, node, nodesByLabel, parallel, podTemplate, powershell, prependToFile, properties, publishChecks, publishHTML, pwd, pwsh, readCSV, readFile, readJSON, readManifest, readMavenPom, readProperties, readTrusted, readYaml, resolveScm, retry, script, sh, sha1, sha256, sleep, sshagent, stage, stash, step, svn, tar, tee, timeout, tm, tool, touch, unarchive, unstable, unstash, untar, unzip, validateDeclarativePipeline, verifySha1, verifySha256, waitUntil, warnError, withChecks, withContext, withCredentials, withEnv, withGroovy, wrap, writeCSV, writeFile, writeJSON, writeMavenPom, writeYaml, ws, zip] or symbols [GitUsernamePassword, all, allBranchesSame, allOf, always, ant, antFromApache, antOutcome, antTarget, any, anyOf, apiToken, architecture, archiveArtifacts, artifactManager, authorizationMatrix, batchFile, bitbucket, bitbucketServer, booleanParam, branch, buildButton, buildDiscarder, buildDiscarders, buildRetention, buildingTag, builtInNode, caseInsensitive, caseSensitive, certificate, changeRequest, changelog, changeset, checkoutToSubdirectory, choice, choiceParam, clock, command, configFile, configFileProvider, configMapVolume, containerEnvVar, containerLivenessProbe, containerTemplate, credentials, cron, crumb, default, defaultFolderConfiguration, defaultView, demand, disableConcurrentBuilds, disableResume, dockerCert, dockerServer, dockerTool, downstream, dumb, durabilityHint, dynamicPVC, emptyDirVolume, emptyDirWorkspaceVolume, envVar, envVars, envVarsFilter, environment, equals, expression, file, fileParam, filePath, fingerprint, fingerprints, frameOptions, freeStyle, freeStyleJob, fromDocker, fromScm, fromSource, git, gitBranchDiscovery, gitHubBranchDiscovery, gitHubBranchHeadAuthority, gitHubExcludeArchivedRepositories, gitHubForkDiscovery, gitHubPullRequestDiscovery, gitHubSshCheckout, gitHubTagDiscovery, gitHubTrustContributors, gitHubTrustEveryone, gitHubTrustNobody, gitHubTrustPermissions, gitTagDiscovery, gitUsernamePassword, github, githubProjectProperty, githubPush, globalConfigFiles, groovy, headRegexFilter, headWildcardFilter, hostPathVolume, hostPathWorkspaceVolume, hyperlink, hyperlinkToModels, inheriting, inheritingGlobal, installSource, isRestartedRun, jdk, jdkInstaller, jgit, jgitapache, jnlp, jobBuildDiscarder, jobDsl, jobName, junitTestResultStorage, kubeconfig, kubernetes, label, lastDuration, lastFailure, lastGrantedAuthorities, lastStable, lastSuccess, legacy, legacySCM, list, local, location, logRotator, loggedInUsersCanDoAnything, mailer, masterBuild, maven, maven3Mojos, mavenErrors, mavenGlobalConfig, mavenMojos, mavenWarnings, merge, modernSCM, myView, namedBranchesDifferent, never, nfsVolume, nfsWorkspaceVolume, node, nodeProperties, nonInheriting, none, not, oc, onFailure, organizationFolder, override, overrideIndexTriggers, paneStatus, parallelsAlwaysFailFast, parameters, password, pattern, permanent, persistentVolumeClaim, persistentVolumeClaimWorkspaceVolume, pipelineTriggers, plainText, plugin, podAnnotation, podEnvVar, podLabel, pollSCM, portMapping, preserveStashes, projectNamingStrategy, proxy, pruneTags, queueItemAuthenticator, quietPeriod, rateLimit, rateLimitBuilds, resourceRoot, retainOnlyVariables, run, runParam, schedule, scmRetryCount, script, scriptApproval, scriptApprovalLink, search, secretEnvVar, secretVolume, security, shell, simpleBuildDiscarder, skipDefaultCheckout, skipStagesAfterUnstable, slave, sourceRegexFilter, sourceWildcardFilter, sshPublicKey, sshUserPrivateKey, standard, status, string, stringParam, suppressAutomaticTriggering, swapSpace, tag, teamSlugFilter, text, textParam, timezone, tmpSpace, toolLocation, triggeredBy, unsecured, untrusted, upstream, url, userSeed, usernameColonPassword, usernamePassword, viewsTabBar, weather, withAnt, x509ClientCert, zip] or globals [cigatingMessage, clientUtils, commonUtils, currentBuild, deployUtils, emailUtils, env, execDeployPipeline, execIQETests, execIQETestsWithNotifier, execQuayCopy, execSmokeTest, gitUtils, iqeUtils, openShiftUtils, openshift, params, pipeline, pipelineUtils, pipelineVars, pythonUtils, rubyUtils, scm, slackUtils]

I'm assuming somebody might want to fix that, but at least doing notifications after deploy will avoid it breaking the deploy itself.

An alternative is wrapping it in try..catch or something but I don't know Jenkins enough (is this "scripted" or "declarative"? :man_shrugging:)