### PR TITLE
Use interpretation of backslash escapes

### DIFF
--- a/src/frontend-build.sh
+++ b/src/frontend-build.sh
@@ -55,7 +55,7 @@ cd $WORKSPACE/build/container_workspace/ && export APP_ROOT="$WORKSPACE/build/co
 # ---------------------------
 
 if [ $IS_PR = true ]; then
-  echo "\n" >> $APP_ROOT/Dockerfile
+  echo -e "\n" >> $APP_ROOT/Dockerfile
   # downstream developers may remove newline at end of dockerfile
   # this will result in something like
   #   CMD npm run start:containerLABEL quay.expires-after=3d


### PR DESCRIPTION
In Bash, without `-e` the new line stays literal and will cause the Dockerfile to be invalid.

See for example failure. https://ci.int.devshift.net/job/RedHatInsights-insights-advisor-frontend-pr-check/292/console