### PR TITLE
Migrate to Caddy for frontend container builds

### DIFF
--- a/src/frontend-build.sh
+++ b/src/frontend-build.sh
@@ -36,7 +36,7 @@ docker run -i --name $CONTAINER_NAME \
   -e CI_ROOT=$CI_ROOT \
   -e NODE_BUILD_VERSION=$NODE_BUILD_VERSION \
   -e SERVER_NAME=$SERVER_NAME \
-  quay.io/cloudservices/frontend-build-container:d60de0c
+  quay.io/cloudservices/frontend-build-container:05ba597
 TEST_RESULT=$?
 
 if [ $TEST_RESULT -ne 0 ]; then


### PR DESCRIPTION
This will not affect any of the currently running Travis builds or Jenkins jobs for Akamai.

* Updates the frontend-build script to use the Caddy based fe build container. 
* Will not affect any repo with an existing `nginx.conf` or `Dockerfile`
* All other repos will now run on Caddy instead of Nginx as new commits hit the build / deploy pipeline. 