### PR TITLE
Add latest tag to docker push

### DIFF
--- a/src/frontend-build.sh
+++ b/src/frontend-build.sh
@@ -85,6 +85,7 @@ export APP_ROOT=${APP_ROOT:-pwd}
 export WORKSPACE=${WORKSPACE:-$APP_ROOT}  # if running in jenkins, use the build's workspace
 # export IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 export GIT_COMMIT=$(git rev-parse HEAD)
+export PR_LATEST="pr-${ghprbPullId}-latest"
 
 
 if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
@@ -102,7 +103,8 @@ DOCKER_CONF="$PWD/.docker"
 mkdir -p "$DOCKER_CONF"
 echo $QUAY_TOKEN | docker --config="$DOCKER_CONF" login -u="$QUAY_USER" --password-stdin quay.io
 echo $RH_REGISTRY_TOKEN | docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" --password-stdin registry.redhat.io
-docker --config="$DOCKER_CONF" build -t "${IMAGE}:${IMAGE_TAG}" $APP_ROOT -f $APP_ROOT/Dockerfile
+docker --config="$DOCKER_CONF" build -t "${IMAGE}:${IMAGE_TAG}" -t "${IMAGE}:${PR_LATEST}" $APP_ROOT -f $APP_ROOT/Dockerfile
 docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
+docker --config="$DOCKER_CONF" push "${IMAGE}:${PR_LATEST}"
 
 teardown_docker

--- a/src/quay_push.sh
+++ b/src/quay_push.sh
@@ -7,6 +7,7 @@ export APP_ROOT=${APP_ROOT:-pwd}
 export WORKSPACE=${WORKSPACE:-$APP_ROOT}  # if running in jenkins, use the build's workspace
 # export IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 export GIT_COMMIT=$(git rev-parse HEAD)
+export LATEST_TAG='latest'
 
 
 if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
@@ -24,5 +25,6 @@ DOCKER_CONF="$PWD/.docker"
 mkdir -p "$DOCKER_CONF"
 docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
-docker --config="$DOCKER_CONF" build -t "${IMAGE}:${IMAGE_TAG}" $APP_ROOT -f $APP_ROOT/Dockerfile
+docker --config="$DOCKER_CONF" build -t "${IMAGE}:${IMAGE_TAG}" -t "${IMAGE}:${LATEST_TAG}" $APP_ROOT -f $APP_ROOT/Dockerfile
 docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
+docker --config="$DOCKER_CONF" push "${IMAGE}:${LATEST_TAG}"


### PR DESCRIPTION
For now, the tags are of the format `<IMAGE>:pr-ghprbPullId-shortSHA` and when merged it's `<IMAGE>:shortSHA`.
It makes hard to predict the tag while doing a local deploy from bonfire. Just the ghprbPullId with latest should be enough to get the latest commit of the PR.
It would be easier if the format during local deploy is `<IMAGE>:pr-ghprbPullId-latest` .
 Also `<IMAGE:latest>` will represent the latest image. 

Same is done in the backend builds.