### PR TITLE
Update frontend-build-container to c892522

### DIFF
--- a/src/frontend-build.sh
+++ b/src/frontend-build.sh
@@ -45,7 +45,7 @@ docker run -i --name $CONTAINER_NAME \
   -e CI_ROOT=$CI_ROOT \
   -e NODE_BUILD_VERSION=$NODE_BUILD_VERSION \
   -e SERVER_NAME=$SERVER_NAME \
-  quay.io/cloudservices/frontend-build-container:f96638d
+  quay.io/cloudservices/frontend-build-container:c892522
 TEST_RESULT=$?
 
 if [ $TEST_RESULT -ne 0 ]; then


### PR DESCRIPTION
This patch changes the ref of the frontend-build-container that we pull to c892522 which contains a change to Caddyfile generation code to properly interpolate the ROUTE_PREFIX variable provided by the operator