### PR TITLE
[RHCLOUD-23162] Temporary fix for chunk-loading

### DIFF
--- a/src/Jenkinsfile
+++ b/src/Jenkinsfile
@@ -49,7 +49,7 @@ node {
            n=0
            until [ \$n -ge 10 ]
            do
-              rsync -arv -e \"ssh -2\" --delete-after * sshacs@cloud-unprotected.upload.akamai.com:${AKAMAI_APP_PATH} && break
+              rsync -arv -e \"ssh -2\" * sshacs@cloud-unprotected.upload.akamai.com:${AKAMAI_APP_PATH} && break
               n=\$[\$n+1]
               sleep 10
            done


### PR DESCRIPTION
We believe the deletion of files after a successful `rsync` is causing Akamai issues. We are turning it off while we investigate further at the suggestion of our Akamai experts.