### PR TITLE
Remove container only if it exists.

### DIFF
--- a/src/frontend-build.sh
+++ b/src/frontend-build.sh
@@ -11,7 +11,7 @@ export IS_PR=false
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
 function teardown_docker() {
-  docker rm -f $CONTAINER_NAME || true
+  [ "$(docker ps -a | grep $CONTAINER_NAME)" ] && docker rm -f $CONTAINER_NAME || true
 }
 
 trap "teardown_docker" EXIT SIGINT SIGTERM


### PR DESCRIPTION
Jenkins job has started failing out of nowhere because sometimes we try to remove the container that no longer exists. Until we figure out why, we should unblock our PR checks.