### PR TITLE
Add BUILD_SCRIPT env var that we pass into the build script

### DIFF
--- a/src/frontend-build.sh
+++ b/src/frontend-build.sh
@@ -127,7 +127,7 @@ docker run -i --name $CONTAINER_NAME \
   -e YARN_BUILD_SCRIPT \
   --add-host stage.foo.redhat.com:127.0.0.1 \
   --add-host prod.foo.redhat.com:127.0.0.1 \
-  quay.io/cloudservices/frontend-build-container:8b281e3 
+  quay.io/cloudservices/frontend-build-container:438485e 
 TEST_RESULT=$?
 
 if [ $TEST_RESULT -ne 0 ]; then


### PR DESCRIPTION
This patch adds a new BUILD_SCRIPT env var that we pass into the build container. Default is `build` - the container will use this for npm run