### PR TITLE
Prevent get_chrome_config from being called

### DIFF
--- a/src/frontend-build.sh
+++ b/src/frontend-build.sh
@@ -184,9 +184,11 @@ if [[ -z "$RH_REGISTRY_USER" || -z "$RH_REGISTRY_TOKEN" ]]; then
     exit 1
 fi
 
-if [ $APP_NAME == "chrome" ] ; then
-  get_chrome_config;
-fi
+# Crome isn't currently using our config, don't need this complexity for now
+# Not deleting, as we may need to re-enable later
+#if [ $APP_NAME == "chrome" ] ; then
+  # get_chrome_config;
+#fi
 
 DOCKER_CONF="$PWD/.docker"
 mkdir -p "$DOCKER_CONF"


### PR DESCRIPTION
RHCLOUD-25502

The chrome service is currnelty sourcing this config elsewhere, rather than add the time and complexity to our build runs, let's just skip this function. Keeping the code around in case they later move to our build flow.