### PR TITLE
Install caddy to the releaser image

### DIFF
--- a/src/releaser.Dockerfile
+++ b/src/releaser.Dockerfile
@@ -1,9 +1,11 @@
-FROM quay.io/fedora/fedora:35-x86_64
+FROM quay.io/fedora/fedora:38-x86_64
 
 ENV GOPATH=/go
 
 RUN dnf update -y && \
-        dnf install nodejs openssh-clients golang -y && \
+        dnf install 'dnf-command(copr)' -y && \
+        dnf copr enable @caddy/caddy -y && \
+        dnf install nodejs caddy rsync unzip openssh-clients golang -y && \
         npm i -g yarn && \
         dnf clean all
 
@@ -19,4 +21,5 @@ RUN mkdir -p /root/.ssh && \
   User git\n\
   IdentitiesOnly yes\n\
   IdentityFile /root/.ssh/ssh_key' >> /etc/ssh/ssh_config && \
-        mkdir -p /go/src
+        mkdir -p /go/src && \
+        mkdir -p /opt/app-root/src


### PR DESCRIPTION
### Description

We will need to use releaser in the better docs, so let's add caddy and other dependencies to run the better docs.