### PR TITLE
Pass git branch and branch name to build script

### DIFF
--- a/src/frontend-build.sh
+++ b/src/frontend-build.sh
@@ -123,6 +123,8 @@ function build() {
     -e DIST_FOLDER \
     -e INCLUDE_CHROME_CONFIG \
     -e CHROME_CONFIG_BRANCH \
+    -e GIT_BRANCH \
+    -e BRANCH_NAME \
     -e NPM_BUILD_SCRIPT \
     -e YARN_BUILD_SCRIPT \
     --add-host stage.foo.redhat.com:127.0.0.1 \


### PR DESCRIPTION
### Description

When running build scripts from within the application we don't have access to branch from which the build was triggered. This is required so apps know if it's running from main/master in order to properly build beta/stable static assets.