### PR TITLE
CI scripts: See APP_ROOT var before use as fallback for WORKSPACE

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -3,8 +3,8 @@
 # --------------------------------------------
 # Export vars for helper scripts to use
 # --------------------------------------------
-export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
+export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export IMAGE="quay.io/cloudservices/releaser"
 export IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -3,8 +3,8 @@
 # --------------------------------------------
 # Export vars for helper scripts to use
 # --------------------------------------------
-export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
+export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export IMAGE="quay.io/cloudservices/releaser"
 export IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 


### PR DESCRIPTION
Might help if one's testing these scripts locally rather than in Jenkins?

The real reason I'm sending this is because we're now [containerizing our app](https://gitlab.cee.redhat.com/service/uhc-portal/-/merge_requests/4357) and copied similar code potentially using APP_ROOT before it's set from [this guide](https://consoledot.pages.redhat.com/docs/dev/containerized-frontends/migration/migration.html#_step_3_add_build_and_pr_check_scripts) and wanted to know if that's intentional (is it expected to be provided externally??) or a bug :wink:  
cc @adamrdrew 