### PR TITLE
Detect container and if it is running delete it

### DIFF
--- a/src/frontend-build.sh
+++ b/src/frontend-build.sh
@@ -45,6 +45,13 @@ function teardown_docker() {
 
 trap "teardown_docker" EXIT SIGINT SIGTERM
 
+# Detect if the container is running
+if docker ps | grep $CONTAINER_NAME > /dev/null; then
+  # Delete it
+  # We do this because an aborted run could leave the container around
+  teardown_docker
+fi
+
 # Get the chrome config from cloud-services-config
 function get_chrome_config() {
   # Create the directory we're gonna plop the config files in


### PR DESCRIPTION
If a job is aborted the build container can be left around. We detect it on start and delete it.