### PR TITLE
remove container if present instead of just running

### DIFF
--- a/src/frontend-build.sh
+++ b/src/frontend-build.sh
@@ -45,8 +45,8 @@ function teardown_docker() {
 
 trap "teardown_docker" EXIT SIGINT SIGTERM
 
-# Detect if the container is running
-if docker ps | grep $CONTAINER_NAME > /dev/null; then
+# Detect if the container exists
+if docker ps -a | grep $CONTAINER_NAME > /dev/null; then
   # Delete it
   # We do this because an aborted run could leave the container around
   teardown_docker


### PR DESCRIPTION
build containers left over from aborted runs don't seem to be running, but they still hog the name, remove them as well