### PR TITLE
Remove PR/MR prefix from image tag

### DIFF
--- a/src/frontend-build.sh
+++ b/src/frontend-build.sh
@@ -104,12 +104,10 @@ if echo $JOB_NAME | grep -w "pr-check" > /dev/null; then
   timestamp=$(date +%s)
 
   if [ ! -z "$ghprbPullId" ]; then
-    export IMAGE_TAG="pr-${ghprbPullId}-${IMAGE_TAG}"
     CONTAINER_NAME="${APP_NAME}-pr-check-${ghprbPullId}-${timestamp}"
   fi
 
   if [ ! -z "$gitlabMergeRequestIid" ]; then
-    export IMAGE_TAG="pr-${gitlabMergeRequestIid}-${IMAGE_TAG}"
     CONTAINER_NAME="${APP_NAME}-pr-check-${gitlabMergeRequestIid}-${timestamp}"
   fi
 


### PR DESCRIPTION
This is already being added in "bootstrap.sh" in the cicd-tools repo which is sourced before this script in "pr_check.sh".

Currently it's creating tags with duplicate PR/MR prefix. See https://quay.io/repository/cloudservices/image-builder-frontend?tab=tags or https://quay.io/repository/cloudservices/insights-inventory-frontend?tab=tags as an example.

This prefix is being added already in `boostrap.sh` in cicd-tools repo here https://github.com/RedHatInsights/cicd-tools/blob/main/bootstrap.sh#L48 

I tried this in our repo and now it behaves correctly: https://github.com/RedHatInsights/image-builder-frontend/pull/1382