### PR TITLE
Revert "Use latest 75bdb61 image build"

### DIFF
--- a/src/frontend-build.sh
+++ b/src/frontend-build.sh
@@ -23,7 +23,7 @@ fi
 export IS_PR=false
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 EPOCH=$(date +%s)
-BUILD_IMAGE_TAG="75bdb61"
+BUILD_IMAGE_TAG="379809a"
 # Get current git branch
 # The current branch is going to be the GIT_BRANCH env var but with origin/ stripped off
 if [[ $GIT_BRANCH == origin/* ]]; then


### PR DESCRIPTION
Reverts RedHatInsights/insights-frontend-builder-common#181

Reverting this because https://gitlab.cee.redhat.com/insights-platform/frontend-build-container/-/merge_requests/57 was reverted. The change caused problems with the builds.