### PR TITLE
Remove invalid character from branch name

### DIFF
--- a/src/frontend-build.sh
+++ b/src/frontend-build.sh
@@ -28,7 +28,7 @@ EPOCH=$(date +%s)
 if [[ $GIT_BRANCH == origin/* ]]; then
     BRANCH_NAME=${GIT_BRANCH:7}
 else
-    BRANCH_NAME=$GIT_BRANCH
+    BRANCH_NAME=${GIT_BRANCH/\//-}
 fi
 # We want to be really, really, really sure we have a unique container name
 export CONTAINER_NAME="$APP_NAME-$BRANCH_NAME-$IMAGE_TAG-$EPOCH"


### PR DESCRIPTION
Container images may only contain `[a-zA-Z0-9][a-zA-Z0-9_.-]`. It is somewhat common to use '/' in branch names, which will create an invalid container image name.

A more complete solution using tr is possible but this is a much simpler change to start.

Example from a [job output](https://ci.ext.devshift.net/job/project-koku-koku-ui-pr-checkmain/526/console):

```
17:20:34 docker: Error response from daemon: Invalid container name (cost-management-ci/reenable-coverage-683fd72-1712683220), only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed.
```