### PR TITLE
feat: remove NodeJS dependency at root level

### DIFF
--- a/src/frontend-build.sh
+++ b/src/frontend-build.sh
@@ -10,7 +10,8 @@ docker --version
 # --------------------------------------------
 # Export vars for helper scripts to use
 # --------------------------------------------
-export APP_NAME=$(node -e "console.log(require(\"${WORKSPACE:-.}${APP_DIR:-}/package.json\").insights.appname)")
+package_json_path="${WORKSPACE:-.}${APP_DIR:-}/package.json"
+export APP_NAME="$(jq -r '.insights.appname' < "$package_json_path")"
 
 # Caller can set a duration for the image life in quay otherwise it is defaulted to 3 days
 : ${QUAY_EXPIRE_TIME:="3d"}

--- a/src/local-build.sh
+++ b/src/local-build.sh
@@ -20,7 +20,8 @@
 # Export vars for helper scripts to use
 # --------------------------------------------
 export WORKSPACE=$(pwd)
-export APP_NAME=$(node -e "console.log(require(\"${WORKSPACE:-.}${APP_DIR:-}/package.json\").insights.appname)")
+package_json_path="${WORKSPACE:-.}${APP_DIR:-}/package.json"
+export APP_NAME="$(jq -r '.insights.appname' < "$package_json_path")"
 export CONTAINER_NAME="$APP_NAME"
 # main IMAGE var is exported from the pr_check.sh parent file
 export IMAGE="quay.io/cloudservices/edge-frontend"

--- a/src/release.sh
+++ b/src/release.sh
@@ -3,8 +3,9 @@ set -e
 set -x
 
 SRC_HASH=`git rev-parse --verify HEAD`
-APP_NAME=$(node -e "console.log(require(\"${WORKSPACE:-.}/package.json\").insights.appname)")
-NODE_VERSION=$(node -e "console.log(require(\"${WORKSPACE:-.}/package.json\")?.engines?.node || \"unknown\")")
+package_json_path="${WORKSPACE:-.}/package.json"
+APP_NAME="$(jq -r '.insights.appname' < "$package_json_path")"
+NODE_VERSION="$(jq -r '.engines.node // "unknown"' < "$package_json_path")"
 
 major_version=0
 # Get the major version of node


### PR DESCRIPTION
replaces NodeJS requirement with `jq` from "top level" operations (NodeJS is required within the actual build containers). 
It is also required in [migrate.sh](https://github.com/RedHatInsights/insights-frontend-builder-common/blob/9892b661a14aadf9facf2903b87c883737089774/src/migrate.sh) but unsure if that is actually used

Should avoid `NodeJS` requirements issues on build nodes