### PR TITLE
fix(frontend-build): expose glitchtip token in build-container

### DIFF
--- a/src/frontend-build.sh
+++ b/src/frontend-build.sh
@@ -136,6 +136,7 @@ function build() {
     -v $PWD:/workspace:ro,Z \
     -e QUAY_USER=$QUAY_USER \
     -e QUAY_TOKEN=$QUAY_TOKEN \
+    -e GLITCHTIP_TOKEN=$GLITCHTIP_TOKEN \
     -e APP_DIR=$APP_DIR \
     -e IS_PR=$IS_PR \
     -e CI_ROOT=$CI_ROOT \
@@ -172,7 +173,7 @@ function build() {
 docker login -u="$QUAY_USER" --password-stdin quay.io <<< "$QUAY_TOKEN"
 docker login -u="$RH_REGISTRY_USER" --password-stdin registry.redhat.io <<< "$RH_REGISTRY_TOKEN"
 
-build  
+build
 
 # Set the APP_ROOT
 cd $WORKSPACE/build/container_workspace/ && export APP_ROOT="$WORKSPACE/build/container_workspace/"


### PR DESCRIPTION
### What

Pass the `GLITCHTIP_TOKEN` env'-var from the parent environment to the frontend build-container's.


### Why

To be used for Sentry-CLI integration inside frontend-apps' build flow.

Example use case:  
The OCM UI (insights app name: 'openshift'), [utilizes][2] sentry CLI to generate and publish sourcemaps.   The CLI's `release` command requires an authentication token, which can be obtained inside jenkins CI runs, by [attaching][1] the `*uhc_insights_platform` secret to the job-template definition.

After OCM UI's migration to build-containers (in staging), this token has become unavailable, apparently as result of the isolated env' inside the FE build-container.

This PR aims to accommodate that use-case, until a more permanent/thought-out solution is implemented.


### Notes

For future implementation/refinement, it was suggested by @Victoremepunto to either allow loading of an app-specific .env file (which will allow any arbitrary vars), or to explicitly inject the whole parent environment onto the FE build-container (which will achieve the same effect).


### Ticketing

Addresses [OCMUI-2114][3]


[1]: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/112778
[2]: https://gitlab.cee.redhat.com/service/uhc-portal/-/merge_requests/5783
[3]: https://issues.redhat.com/browse/OCMUI-2114
