### PR TITLE
Fix for the releaser image not building

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,36 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# --------------------------------------------
-# Export vars for helper scripts to use
-# --------------------------------------------
-export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
-export APP_ROOT=$(pwd)
-export IMAGE="quay.io/cloudservices/releaser"
-export IMAGE_TAG=$(git rev-parse --short=7 HEAD)
+# shellcheck source=/dev/null
+source <(curl -sSL https://raw.githubusercontent.com/RedHatInsights/cicd-tools/main/src/bootstrap.sh) image_builder
 
-set -exv
+export CICD_IMAGE_BUILDER_IMAGE_NAME='quay.io/cloudservices/releaser'
+export CICD_IMAGE_BUILDER_CONTAINERFILE_PATH='src/releaser.Dockerfile'
 
-if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
-    echo "QUAY_USER and QUAY_TOKEN must be set"
-    exit 1
-fi
-
-if [[ -z "$RH_REGISTRY_USER" || -z "$RH_REGISTRY_TOKEN" ]]; then
-    echo "RH_REGISTRY_USER and RH_REGISTRY_TOKEN must be set"
-    exit 1
-fi
-
-DOCKER_CONF="$PWD/.docker"
-mkdir -p "$DOCKER_CONF"
-docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
-docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
-docker --config="$DOCKER_CONF" build -t "${IMAGE}:${IMAGE_TAG}" $APP_ROOT -f $APP_ROOT/src/releaser.Dockerfile
-docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
-
-# Stubbed out for now
-mkdir -p $WORKSPACE/artifacts
-cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
-<testsuite tests="1">
-    <testcase classname="dummy" name="dummytest"/>
-</testsuite>
-EOF
+cicd::image_builder::build_and_push

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,38 +1,19 @@
 #!/bin/bash
 
-# --------------------------------------------
-# Export vars for helper scripts to use
-# --------------------------------------------
-export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
-export APP_ROOT=$(pwd)
-export IMAGE="quay.io/cloudservices/releaser"
-export IMAGE_TAG=$(git rev-parse --short=7 HEAD)
+# shellcheck source=/dev/null
+source <(curl -sSL https://raw.githubusercontent.com/RedHatInsights/cicd-tools/main/src/bootstrap.sh) common
 
-set -exv
-
-if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
-    echo "QUAY_USER and QUAY_TOKEN must be set"
-    exit 1
+if ! ./build_deploy.sh; then
+  echo "Error building image"
+  exit 1
 fi
 
-if [[ -z "$RH_REGISTRY_USER" || -z "$RH_REGISTRY_TOKEN" ]]; then
-    echo "RH_REGISTRY_USER and RH_REGISTRY_TOKEN must be set"
-    exit 1
-fi
-
-echo "LABEL quay.expires-after=3d" >> $APP_ROOT/src/releaser.Dockerfile
-
-DOCKER_CONF="$PWD/.docker"
-mkdir -p "$DOCKER_CONF"
-docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
-docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
-docker --config="$DOCKER_CONF" build -t "${IMAGE}:${IMAGE_TAG}" $APP_ROOT -f $APP_ROOT/src/releaser.Dockerfile
-docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
-
-# Stubbed out for now
-mkdir -p $WORKSPACE/artifacts
-cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
-<testsuite tests="1">
-    <testcase classname="dummy" name="dummytest"/>
-</testsuite>
+if cicd::common::is_ci_context; then
+  # Stubbed out for now
+  mkdir 'artifacts'
+  cat << EOF > 'artifacts/junit-dummy.xml'
+  <testsuite tests="1">
+      <testcase classname="dummy" name="dummytest"/>
+  </testsuite>
 EOF
+fi

--- a/src/releaser.Dockerfile
+++ b/src/releaser.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:38-x86_64
+FROM quay.io/fedora/fedora:40-x86_64
 
 ENV GOPATH=/go
 


### PR DESCRIPTION
- Fixes the failing image build process by bumping the base image tag
- Refactors the `pr-check.sh` and `build-deploy.sh` scripts to leverage the CICD-tools ilbrary