### PR TITLE
Make running verification optional

### DIFF
--- a/src/frontend-build.sh
+++ b/src/frontend-build.sh
@@ -160,6 +160,7 @@ build() {
     -e BRANCH_NAME \
     -e NPM_BUILD_SCRIPT \
     -e YARN_BUILD_SCRIPT \
+    -e SKIP_VERIFY \
     --add-host stage.foo.redhat.com:127.0.0.1 \
     --add-host prod.foo.redhat.com:127.0.0.1 \
     quay.io/cloudservices/frontend-build-container:latest
@@ -204,6 +205,9 @@ if running_in_ci && ! setup_docker_login; then
     echo "Error configuring Docker login"
     exit 1
 fi
+
+# Caller might want to skip verification
+export SKIP_VERIFY=${SKIP_VERIFY:-}
 
 build
 


### PR DESCRIPTION
We run verification in a separate github action and don't need to run it again during the container image build. Other teams might want that as well so making this into another env var that can be set.