### PR TITLE
src/frontend-build: pass along sentry variables

### DIFF
--- a/src/frontend-build.sh
+++ b/src/frontend-build.sh
@@ -161,6 +161,10 @@ build() {
     -e NPM_BUILD_SCRIPT \
     -e YARN_BUILD_SCRIPT \
     -e SKIP_VERIFY \
+    -e SENTRY_DSN \
+    -e SENTRY_AUTH_TOKEN \
+    -e SENTRY_ORG \
+    -e SENTRY_PROJECT \
     --add-host stage.foo.redhat.com:127.0.0.1 \
     --add-host prod.foo.redhat.com:127.0.0.1 \
     quay.io/cloudservices/frontend-build-container:3bacc0b


### PR DESCRIPTION
These variables can be used by the sentry webpack plugin to upload source maps.