### PR TITLE
Change caddy-ubi to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY --chown=default . .
 
 RUN universal_build.sh
 
-FROM quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:0d6954b
+FROM quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:latest
 
 COPY LICENSE /licenses/
 


### PR DESCRIPTION
Managing this is too onerous. I'm setting it to latest. Whatever theoretical value there is in determinism it is far outweighed by the burden of managing this.