### PR TITLE
Allow configuration of assets public path via env variable.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ FROM quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:latest
 COPY LICENSE /licenses/
 
 ENV CADDY_TLS_MODE http_port 8000
+# fallback value to the env public path env variable
+# Caddy must have a default value for the public path or it will not start
+ENV ENV_PUBLIC_PATH "/default"
 
 COPY --from=builder /opt/app-root/src/Caddyfile /etc/caddy/Caddyfile
 COPY --from=builder /opt/app-root/src/dist dist

--- a/server_config_gen.sh
+++ b/server_config_gen.sh
@@ -41,6 +41,19 @@ generate_caddy_config() {
 		}
 	}
 
+  # Handle env based main route
+  @env_match {
+      path {\$ENV_PUBLIC_PATH}*
+  }
+
+  handle @env_match {
+      uri strip_prefix {\$ENV_PUBLIC_PATH}
+      file_server * {
+          root /srv/${OUTPUT_DIR}
+          browse
+      }
+  }
+
 	handle / {
 		redir /apps/chrome/index.html permanent
 	}


### PR DESCRIPTION
Required for IoP, we need our frontends to be served from configurable paths, not from paths defined for HCC.

PR: https://issues.redhat.com/browse/RHCLOUD-39666

## Summary by Sourcery

Add support for configuring the public path for frontend assets using an environment variable

Enhancements:
- Modify Caddy configuration to support dynamic public path routing based on an environment variable

Deployment:
- Add ENV_PUBLIC_PATH environment variable to Dockerfile with a fallback default value