### PR TITLE
Correct formatting and paths in generated Caddyfile

### DIFF
--- a/server_config_gen.sh
+++ b/server_config_gen.sh
@@ -13,41 +13,38 @@ generate_caddy_config() {
 
   local ROUTE_PATH=${ROUTE_PATH:-"/apps/${APP_NAME}"}
 
-  # The spacing on the bash format here makes the closing bracket
-  # look odd, but it's fine.
   echo "{
-    {\$CADDY_TLS_MODE}
-    auto_https disable_redirects
-    servers {
-      metrics
-    }
+	{\$CADDY_TLS_MODE}
+	auto_https disable_redirects
+	servers {
+		metrics
+	}
 }
 
 :9000 {
-    metrics /metrics
-  }
-
-  :8000 {
-    {\$CADDY_TLS_CERT}
-    log
-
-    # Handle main app route
-    @app_match {
-        path ${ROUTE_PATH}*
-    }
-    handle @app_match {
-        uri strip_prefix ${ROUTE_PATH}
-        file_server * {
-            root /srv/${OUTPUT_DIR}
-            browse
-        }
-    }
-
-    handle / {
-        redir /apps/chrome/index.html permanent
-    }
+	metrics /metrics
 }
-    "
+
+:8000 {
+	{\$CADDY_TLS_CERT}
+	log
+
+	# Handle main app route
+	@app_match {
+		path ${ROUTE_PATH}*
+	}
+	handle @app_match {
+		uri strip_prefix ${ROUTE_PATH}
+		file_server * {
+			root /srv/${OUTPUT_DIR}
+			browse
+		}
+	}
+
+	handle / {
+		redir /apps/chrome/index.html permanent
+	}
+}"
 }
 
 generate_docker_ignore() {


### PR DESCRIPTION
Format the Caddyfile so that it passes caddy fmt validation. Without these changes, a warning is issued when the container runs.

```
2025/04/23 16:40:36.210	WARN	Caddyfile input is not formatted; run 'caddy fmt --overwrite' to fix inconsistencies
```