### PR TITLE
add NPM_BUILD_SCRIPT as a build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN npm i -g yarn
 COPY build-tools/universal_build.sh build-tools/build_app_info.sh build-tools/server_config_gen.sh /opt/app-root/bin/
 COPY --chown=default . .
 
+ARG NPM_BUILD_SCRIPT=""
 RUN universal_build.sh
 
 FROM quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:latest


### PR DESCRIPTION
The universal_build.sh script makes use of the NPM_BUILD_SCRIPT envvar to customize the build step, but the envvar cannot currently be used.

Adding `ARG NPM_BUILD_SCRIPT=""` to the Dockerfile allows NPM_BUILD_SCRIPT to be modified via a build-arg 