### PR TITLE
Adding the valpop utility to every frontend image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ ENV CADDY_TLS_MODE http_port 8000
 # Caddy must have a default value for the public path or it will not start
 ENV ENV_PUBLIC_PATH "/default"
 
+# Copy the valpop binary from the valpop image
+COPY --from=quay.io/redhat-services-prod/hcc-platex-services-tenant/valpop:latest /usr/local/bin/valpop /usr/local/bin/valpop
+
 COPY --from=builder /opt/app-root/src/Caddyfile /etc/caddy/Caddyfile
 COPY --from=builder /opt/app-root/src/dist dist
 COPY package.json .


### PR DESCRIPTION
Needed for the pushcache work. We will be triggering the valpop utility from a job using the frontend-operator.

Tested locally by doing the following:

1. Copied this repo inside a frontend repo under a directory named `build-tools`
2. Built the image using: `podman build --no-cache -t frontend-test-valpop -f build-tools/Dockerfile .`
3. Ran the image using: `podman run -it va-frontend-test-valpop:latest sh`
4. Ran `valpop --help`