### PR TITLE
feat(RHINENG-19424): Create Sentry vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,14 @@ USER default
 
 RUN npm i -g yarn
 
+# ────────── SENTRY BUILD ARGS ──────────
+ARG ENABLE_SENTRY=false
+ARG SENTRY_AUTH_TOKEN
+ARG SENTRY_RELEASE
+ENV ENABLE_SENTRY=${ENABLE_SENTRY} \
+    SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN} \
+    SENTRY_RELEASE=${SENTRY_RELEASE}
+
 COPY build-tools/universal_build.sh build-tools/build_app_info.sh build-tools/server_config_gen.sh /opt/app-root/bin/
 COPY --chown=default . .
 


### PR DESCRIPTION
The uploading of source maps needs to be done through konflux now. In order to do this, sentry vars passed into the tekton build-args in order to enable the sentry webpackplugin. This should have no affect on anything else as its just setting up variables 