### PR TITLE
fix(RHINENG:19424): Grab sentry tokens from konflux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,13 @@ USER default
 RUN npm i -g yarn
 
 # ────────── SENTRY BUILD ARGS ──────────
+# NOTE:
+# Tekton/Konflux passes values like --build-arg ENABLE_SENTRY=true and
+# --build-arg SENTRY_RELEASE=<commit SHA> during the build.
+# ARG makes them available only at build-time.
+# The ENV line copies them into the final container so they persist at runtime,
+# letting Node (process.env.ENABLE_SENTRY, process.env.SENTRY_RELEASE, etc.)
+# and other tools read them.
 ARG ENABLE_SENTRY=false
 ARG SENTRY_AUTH_TOKEN
 ARG SENTRY_RELEASE


### PR DESCRIPTION
For full scope: 

One Konflux secret (sentry-auth) for all apps. (each app lives in this one token)

Each app only sets ENABLE_SENTRY=true in its own push.yaml. (so apps that dont use sentry dont initialize anything

If an app’s key/token exists → sourcemaps upload.

If it doesn’t → plugin is not activated; build succeeds; no token ever printed.

In your Dockerfile I set ARG ENABLE_SENTRY=false, so if an app doesn’t pass it, it defaults to false.