### PR TITLE
feat: remove test and lint during build

### DIFF
--- a/Dockerfile.hermetic
+++ b/Dockerfile.hermetic
@@ -16,10 +16,6 @@ COPY . .
 # Run the build process
 RUN npm run build
 
-# Run tests and linting
-RUN npm run test
-RUN npm run lint
-
 # Stage 2: Semi-minimal runtime image - contains only built files and minimal dependencies for the RH certification
 
 # To achieve a hermetic build with minimal container size, you can request an exception for the image to use a base image 


### PR DESCRIPTION
Running test in the container build slows down image builds tremendously.
Unless this is required to be done during build, it can be removed.