### PR TITLE
Add option to pass additional secrets to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,49 @@
 
 The repo responsible for building all of the frontends on cloud.redhat.com.
 
+## Build Secrets Management
+
+This Dockerfile supports passing build secrets via Konflux as a `.env` file format. The secrets are parsed and made available during the build process, with special handling for Sentry authentication tokens.
+
+### Passing Build Secret Variables
+
+Build secrets can be passed to the container using Konflux's secret mounting mechanism. The secrets are expected to be in `.env` file format with the following structure:
+
+```
+KEY1=value1
+KEY2=value2
+# Comments are supported
+INVENTORY_SECRET=your-secret-value
+```
+
+**Key features:**
+- Secrets are mounted at `/run/secrets/build-container-additional-secret/secrets`
+- You have to name your secret as `build-container-additional-secret` inside of it create a single key/value secret with key as `secrets` and value contents of your `.env` file
+- The `parse-secrets.sh` script automatically parses the `.env` file format
+- Comments (lines starting with `#`) and empty lines are ignored
+- All key-value pairs are exported as environment variables during the build
+- The script gracefully handles missing secret files (exits with code 0)
+
+### Setting Sentry Auth Token
+
+The build process includes automatic Sentry authentication token detection based on a naming convention. If a secret variable follows the pattern `{APP_NAME}_SECRET`, it will be automatically used as the `SENTRY_AUTH_TOKEN`.
+
+**How it works:**
+1. The build process extracts the application name from `package.json`
+2. It constructs the expected secret variable name: `{APP_NAME}_SECRET`
+3. If this variable exists in the parsed secrets, it automatically:
+   - Sets `ENABLE_SENTRY=true`
+   - Sets `SENTRY_AUTH_TOKEN` to the value of `{APP_NAME}_SECRET`
+   - Enables Sentry sourcemap upload for the build
+
+**Example:**
+For an application named "inventory", if you provide a secret named `INVENTORY_SECRET=your-sentry-token`, the build will automatically:
+- Enable Sentry integration
+- Use the provided token for sourcemap uploads
+- Display: `"Sentry: token found for inventory – enabling sourcemap upload."`
+
+If no matching secret is found, the build continues with any pre-configured Sentry settings or skips Sentry upload entirely.
+
 ## Akamai Cache Buster
 
 This script is run automatically from Jenkins each time a frontend is deployed

--- a/parse-secrets.sh
+++ b/parse-secrets.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Script to parse .env secrets file and set environment variables
+# Expected .env structure: KEY=VALUE (one per line)
+# Lines starting with # are treated as comments and ignored
+# Empty lines are ignored
+
+SECRETS_FILE="/run/secrets/build-container-additional-secret/secrets"
+
+if [ ! -f "$SECRETS_FILE" ]; then
+    echo "Error: Secrets file not found at $SECRETS_FILE"
+    exit 0
+fi
+
+# Parse .env file and export environment variables
+while IFS= read -r line || [[ -n "$line" ]]; do
+    # Skip empty lines and comments
+    if [[ -z "$line" ]] || [[ "$line" =~ ^[[:space:]]*# ]]; then
+        continue
+    fi
+    
+    # Check if line contains = and split into key=value
+    if [[ "$line" =~ ^[^=]+= ]]; then
+        # Extract key and value
+        key="${line%%=*}"
+        value="${line#*=}"
+        
+        # Remove any leading/trailing whitespace from key
+        key=$(echo "$key" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        
+        if [[ -n "$key" ]]; then
+            export "$key"="$value"
+            echo "Set environment variable: $key"
+        fi
+    fi
+done < "$SECRETS_FILE"
+
+# Execute the command passed as arguments
+exec "$@"


### PR DESCRIPTION
### Description

Let's add option to pass additional secrets to build so they can later be used in the build commands. This PR adds parse secrets script which mounts additional secrets, parses the .env file and sets the variables.