### PR TITLE
chore(deps): bump base node image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 # To find available tags, visit:
 # https://catalog.redhat.com/software/containers/ubi9/nodejs-22/62e8e7ed22d1d3c2dfe2ca01
 ARG NODE_BUILD_VERSION=22
-ARG NODE_IMAGE_TAG=9.7-1776920122
+ARG NODE_IMAGE_TAG=9.7-1777958137
 FROM registry.access.redhat.com/ubi9/nodejs-${NODE_BUILD_VERSION}:${NODE_IMAGE_TAG} as builder
 
 USER root


### PR DESCRIPTION
### Description
<!-- Summary of proposed changes: what and why. -->
<!-- Which downstream repos/teams are affected? -->
Fresh image seems being good if we speak about CVEs https://catalog.redhat.com/en/software/containers/ubi9/nodejs-22/66431d1785c5c3a31edd24f1#security

Meanwhile image that we currently use has some important CVEs https://catalog.redhat.com/en/software/containers/ubi9/nodejs-22/66431d1785c5c3a31edd24f1?image=69c41d07dc780ad22a4912f4&architecture=ppc64le#security

We were asked to update base image for FedRAMP
---

### Blast radius
<!-- Who/what consumes this? List affected repos, services, or pipelines. -->
<!-- How was this tested against consumers? -->

---

### Rollback plan
<!-- If this breaks production, how do we revert? -->
<!-- Is git revert sufficient, or are there additional steps? -->

---

### Checklist
- [ ] Tested against at least one consuming repo/service
- [ ] No breaking changes to existing consumers (or migration path documented)
- [ ] No hardcoded secrets, tokens, or passwords
- [ ] Container images pinned to specific tags, not `latest`

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->
