### PR TITLE
fix(logging): remove sentry var logging

### DIFF
--- a/universal_build.sh
+++ b/universal_build.sh
@@ -16,6 +16,9 @@ SECRET_VAR_NAME="${APP_NAME_FOR_SECRET}_SECRET"
 USES_NPM=false
 USES_YARN=false
 
+# Disable verbose output to hide Sentry token from logs
+{ old_opts=$(set +o); set +x; } 2>/dev/null
+
 if [[ -n "${!SECRET_VAR_NAME:-}" ]]; then
   export ENABLE_SENTRY=true
   export SENTRY_AUTH_TOKEN="${!SECRET_VAR_NAME}"
@@ -23,6 +26,8 @@ if [[ -n "${!SECRET_VAR_NAME:-}" ]]; then
 else
   echo "Sentry: no token for ${APP_NAME_FOR_SECRET} – using any pre-set token (if provided) or skipping upload."
 fi
+# Restore previous shell options (re-enables verbose output)
+{ eval "$old_opts"; } 2>/dev/null
 
 # Configure git to trust this directory
 git config --global --add safe.directory /opt/app-root/src


### PR DESCRIPTION
Remove the logging of the values of the sentry variables in builds