### PR TITLE
feat(build): add pnpm support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,9 +24,10 @@ insights-frontend-builder-common/
 ├── Dockerfile                    # Primary multi-stage build (Node.js builder → Caddy runtime)
 ├── Dockerfile.hermetic           # Hermetic/airgapped build variant (Node.js → ubi-micro)
 ├── application.Dockerfile        # Legacy Dockerfile using pre-built builder image
-├── universal_build.sh            # Main build orchestrator (npm/yarn detect, install, build)
+├── universal_build.sh            # Main build orchestrator (npm/yarn/pnpm detect, install, build)
 ├── build_app_info.sh             # Generates app.info.json with build metadata
 ├── server_config_gen.sh          # Generates Caddyfile, .dockerignore, app.info.json
+├── dependency_helpers.sh          # Shared lockfile/dependency metadata helpers
 ├── parse-secrets.sh              # Parses .env secrets from Konflux secret mounts
 ├── README.md                     # Main documentation
 ├── README-hermetic-build.md      # Hermetic build setup guide
@@ -89,8 +90,8 @@ The build is triggered by `podman build -f build-tools/Dockerfile .` and follows
    - Copies application source
    - Runs `parse-secrets.sh` to load Konflux secrets
    - Runs `universal_build.sh` which:
-     - Detects npm vs yarn (via lock file presence)
-     - Runs `npm ci` or `yarn install --immutable`
+   - Detects npm vs yarn vs pnpm (via lock file presence)
+   - Runs `npm ci`, `yarn install --immutable`, or `pnpm install --frozen-lockfile`
      - Runs the build command (`npm run build` or custom script)
      - Generates `app.info.json` via `build_app_info.sh`
      - Generates Caddyfile via `server_config_gen.sh`
@@ -118,7 +119,8 @@ The build is triggered by `podman build -f build-tools/Dockerfile .` and follows
 | `SENTRY_AUTH_TOKEN` | (none) | Sentry authentication token |
 | `SENTRY_RELEASE` | (none) | Sentry release identifier |
 | `APP_VERSION` | `unknown` | Application version for app.info.json |
-| `NPM_BUILD_SCRIPT` | (empty) | Custom npm build script name |
+| `NPM_BUILD_SCRIPT` | (empty) | Custom npm build script name; also used by pnpm for existing pipeline compatibility |
+| `PNPM_BUILD_SCRIPT` | (empty) | Custom pnpm build script name |
 | `YARN_BUILD_SCRIPT` | (empty) | Custom yarn build script name |
 | `USES_YARN` | `false` | Force yarn build system |
 | `SOURCE_GIT_BRANCH` | (empty) | Git branch for detached HEAD CI |
@@ -164,7 +166,7 @@ cd test && make install
 
 1. **Shell scripts**: Use `set -euo pipefail` at the top. Use `set -exv` for verbose debug output during builds.
 2. **Conventional commits**: Follow `type(scope): description` format. Types: `fix`, `feat`, `chore`, `docs`, `test`, `ci`. Renovate uses `chore(deps):` for dependency updates.
-3. **Build system detection**: Always detect npm vs yarn by checking for `package-lock.json` or `yarn.lock`. Never hardcode one.
+3. **Build system detection**: `universal_build.sh` `setPackageManager` must detect npm vs yarn vs pnpm by checking for `package-lock.json`, `yarn.lock`, and `pnpm-lock.yaml`. It must fail when none or more than one of those lockfiles exists, and select the package manager only when exactly one supported lockfile is present.
 4. **Environment variables**: Use `ARG` for build-time, `ENV` to persist to runtime. Document every ARG in the Dockerfile with comments.
 5. **Secrets handling**: Never log secret values. Use the `parse-secrets.sh` pattern for `.env` format secrets from Konflux mounts.
 6. **Python tests**: Use pytest classes (e.g., `TestDockerfileCaddy`). Each test class builds its own container image and cleans up.
@@ -174,7 +176,7 @@ cd test && make install
 ## Common Pitfalls
 
 1. **Detached HEAD in CI**: Konflux/Tekton checks out a detached HEAD, so `git branch --show-current` returns empty. `build_app_info.sh` has a 4-step fallback: current branch, abbrev-ref, remote branch, CI env vars (`SOURCE_GIT_BRANCH`, `GITHUB_HEAD_REF`, etc.).
-2. **npm vs yarn detection**: `universal_build.sh` checks for lock files. If neither `package-lock.json` nor `yarn.lock` exists, the build fails. Both cannot be present.
+2. **Package manager detection**: `universal_build.sh` `setPackageManager` builds the supported lockfile list from `package-lock.json`, `yarn.lock`, and `pnpm-lock.yaml`. If none exist, the build fails. If more than one exists, the build also fails instead of choosing by precedence. Exactly one lockfile sets the matching `USES_NPM`, `USES_YARN`, or `USES_PNPM` path for install and build.
 3. **Secret naming convention**: Sentry tokens use `{APP_NAME}_SECRET` where `APP_NAME` comes from `package.json` `insights.appname`, uppercased with dashes replaced by underscores.
 4. **Multi-stage build variables**: `ARG` values set in the builder stage do NOT persist to the runtime (Caddy) stage. Only `ENV` values set in the final stage are available at runtime.
 5. **Test fixture setup**: Tests dynamically copy the Dockerfile and scripts from repo root to `test-fixtures/fake-app/build-tools/` before each run. Don't manually place files there.

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN dnf install jq -y
 
 USER default
 
-RUN npm i -g yarn
+RUN npm i -g pnpm yarn
 
 # ────────── SENTRY BUILD ARGS ──────────
 # NOTE:
@@ -48,6 +48,10 @@ ENV APP_VERSION=${APP_VERSION}
 ARG NPM_BUILD_SCRIPT=""
 ENV NPM_BUILD_SCRIPT=${NPM_BUILD_SCRIPT}
 
+# Persist pnpm build script at runtime.
+ARG PNPM_BUILD_SCRIPT=""
+ENV PNPM_BUILD_SCRIPT=${PNPM_BUILD_SCRIPT}
+
 # Persist yarn build script at runtime.
 ARG YARN_BUILD_SCRIPT=""
 ARG USES_YARN=false
@@ -68,7 +72,7 @@ ARG APP_BUILD_DIR=dist
 ARG PACKAGE_JSON_PATH=package.json
 ENV PACKAGE_JSON_PATH=${PACKAGE_JSON_PATH}
 
-COPY build-tools/universal_build.sh build-tools/build_app_info.sh build-tools/server_config_gen.sh /opt/app-root/bin/
+COPY build-tools/universal_build.sh build-tools/build_app_info.sh build-tools/server_config_gen.sh build-tools/dependency_helpers.sh /opt/app-root/bin/
 COPY --chown=default . .
 
 RUN chmod +x build-tools/parse-secrets.sh

--- a/build_app_info.sh
+++ b/build_app_info.sh
@@ -20,6 +20,10 @@
 
 export PACKAGE_JSON_PATH=${PACKAGE_JSON_PATH:-package.json}
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=dependency_helpers.sh
+source "${SCRIPT_DIR}/dependency_helpers.sh" || exit 1
+
 get_package_value() {
   local key="$1"
 
@@ -28,18 +32,21 @@ get_package_value() {
 
 # handle_npm_list
 # Purpose: Retrieve a comma-separated list of dependency versions for a given scope.
+# Uses the detected lockfile family so npm, yarn, and pnpm projects can all
+# populate dependency metadata after install.
 # Parameters:
-#   - dependency_scope: A string to grep for in the npm list, e.g. a scope or package name.
+#   - dependency_scope: A string to match in the package manager list,
+#     e.g. a scope or package name.
 # Usage: handle_npm_list <dependency_scope>
 # Example: handle_npm_list "@patternfly"
 handle_npm_list() {
   local dependency_scope="$1"
 
   # Check if a lock file exists, suggesting that the node_modules directory is present.
-  if [[ -f package-lock.json ]] || [[ -f yarn.lock ]]; then
+  if has_supported_lock_file; then
     # Retrieve and format the dependency list. If unsuccessful, return an empty string.
     local dep_list
-    dep_list=$(npm list --silent --depth=0 --production | grep "$dependency_scope" -i | sed -E "s/^(.{0})(.{4})/\1/" | tr "\n" "," | sed -E "s/,/\",\"/g" || echo "")
+    dep_list=$(list_dependency_versions "$dependency_scope")
 
     # Check if the dependency list is empty and log an error message if so.
     if [[ -z "$dep_list" ]]; then
@@ -50,7 +57,7 @@ handle_npm_list() {
     fi
   else
     # If no lock file is present, log an error message and return an empty string.
-    echo "Error: No package-lock.json or yarn.lock file found. Cannot retrieve dependency list for '$dependency_scope'." >&2
+    echo "Error: No supported lock file found. Cannot retrieve dependency list for '$dependency_scope'." >&2
     echo ""
   fi
 }
@@ -137,8 +144,8 @@ APP_VERSION=${APP_VERSION:-unknown}
 
 PATTERNFLY_DEPS=$(handle_npm_list "@patternfly")
 RH_CLOUD_SERVICES_DEPS=$(handle_npm_list "@redhat-cloud-services")
-PATTERNFLY_DEPS="[\"${PATTERNFLY_DEPS%???}\"]"
-RH_CLOUD_SERVICES_DEPS="[\"${RH_CLOUD_SERVICES_DEPS%???}\"]"
+PATTERNFLY_DEPS=$(format_dependency_array "$PATTERNFLY_DEPS")
+RH_CLOUD_SERVICES_DEPS=$(format_dependency_array "$RH_CLOUD_SERVICES_DEPS")
 
 # JSON generation with `jq`
 jq -n \

--- a/dependency_helpers.sh
+++ b/dependency_helpers.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+
+has_supported_lock_file() {
+  [[ -f package-lock.json ]] || [[ -f yarn.lock ]] || [[ -f pnpm-lock.yaml ]]
+}
+
+list_dependency_versions() {
+  local dependency_scope="$1"
+  local list_json
+
+  if [[ -f pnpm-lock.yaml ]]; then
+    if ! list_json=$(pnpm list --json --depth=0 --prod 2>/dev/null); then
+      list_json="[]"
+    fi
+  else
+    if ! list_json=$(npm list --silent --json --depth=0 --production 2>/dev/null); then
+      list_json="{}"
+    fi
+  fi
+
+  jq -r --arg scope "$dependency_scope" '
+    ($scope | ascii_downcase) as $needle
+    | (if type == "array" then .[0] else . end).dependencies // {}
+    | to_entries
+    | map(
+        select(.key | ascii_downcase | contains($needle))
+        | "\(.key)@\(.value.version // "unknown")"
+      )
+    | join("\",\"")
+  ' <<< "$list_json" || echo ""
+}
+
+format_dependency_array() {
+  local dependency_list="$1"
+
+  if [[ -n "$dependency_list" ]]; then
+    echo "[\"${dependency_list}\"]"
+  else
+    echo "[]"
+  fi
+}

--- a/docs/architecture-guidelines.md
+++ b/docs/architecture-guidelines.md
@@ -9,7 +9,7 @@ Consumer frontend app (e.g., insights-chrome, notifications-frontend)
 │
 ├── src/                     ← App source code
 ├── package.json             ← Must have insights.appname
-├── package-lock.json        ← Or yarn.lock
+├── package-lock.json        ← Or yarn.lock / pnpm-lock.yaml
 ├── LICENSE                  ← Required by Dockerfile
 └── build-tools/             ← Git submodule → this repo
     ├── Dockerfile           ← Multi-stage build definition
@@ -47,8 +47,8 @@ Key operations:
 1. `parse-secrets.sh` loads Konflux secrets
 2. Auto-detect Sentry token from `{APP_NAME}_SECRET`
 3. Detect npm vs yarn from lock files
-4. `npm ci` / `yarn install --immutable`
-5. `npm run build` / `yarn build:prod` (or custom script)
+4. `npm ci` / `yarn install --immutable` / `pnpm install --frozen-lockfile`
+5. `npm run build` / `yarn build:prod` / `pnpm run build` (or custom script)
 6. `build_app_info.sh` generates build metadata JSON
 7. `server_config_gen.sh` generates Caddy config
 
@@ -143,7 +143,7 @@ git submodule add https://github.com/RedHatInsights/insights-frontend-builder-co
 | File | Requirement |
 |------|-------------|
 | `package.json` | Must have `insights.appname` field |
-| `package-lock.json` or `yarn.lock` | Exactly one must exist |
+| `package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml` | Exactly one must exist |
 | `LICENSE` | Copied to `/licenses/` for compliance |
 | Build output | Must produce a `dist/` directory (or custom `APP_BUILD_DIR`) |
 

--- a/docs/build-script-guidelines.md
+++ b/docs/build-script-guidelines.md
@@ -30,20 +30,22 @@ Use `set -exv` only in `universal_build.sh` for build-time debug output.
 
 ### Package Manager Detection
 
-The build system supports both npm and yarn. Detection is based on lock file presence:
+The build system supports npm, yarn, and pnpm. Detection is based on lock file presence:
 
 ```bash
 if [[ -f package-lock.json ]]; then
     USES_NPM=true
 elif [[ -f yarn.lock ]]; then
     USES_YARN=true
+elif [[ -f pnpm-lock.yaml ]]; then
+    USES_PNPM=true
 else
     echo "No lock file found"
     exit 1
 fi
 ```
 
-When adding new functionality that invokes npm or yarn commands, always branch on `USES_NPM` and `USES_YARN`. Never hardcode one package manager.
+When adding new functionality that invokes package manager commands, always branch on `USES_NPM`, `USES_YARN`, and `USES_PNPM`. Never hardcode one package manager.
 
 ### Environment Variable Conventions
 
@@ -137,7 +139,7 @@ Key rules:
 ## Checklist for Changes
 
 - [ ] Script has `set -euo pipefail` header
-- [ ] Both npm and yarn paths handled (if applicable)
+- [ ] npm, yarn, and pnpm paths handled (if applicable)
 - [ ] New ARGs documented with comment blocks
 - [ ] New env vars tested in `test/test_dockerfile_env_vars.py`
 - [ ] Secret values never logged

--- a/server_config_gen.sh
+++ b/server_config_gen.sh
@@ -5,6 +5,10 @@ export LANG=en_US.utf-8
 GIT_COMMIT=$(git rev-parse HEAD)
 export GIT_COMMIT
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=dependency_helpers.sh
+source "${SCRIPT_DIR}/dependency_helpers.sh" || exit 1
+
 NPM_INFO="undefined"
 PATTERNFLY_DEPS="undefined"
 export USES_CADDY=true
@@ -70,11 +74,12 @@ EOF
 
 # FIXME: How's this any different from the "build_app_info.sh script??"
 generate_app_info() {
-  if [[ -f package-lock.json ]] || [[ -f yarn.lock ]]; then
-    LINES=$(npm list --silent --depth=0 --production | grep @patternfly -i | sed -E "s/^(.{0})(.{4})/\1/" | tr "\n" "," | sed -E "s/,/\",\"/g")
-    PATTERNFLY_DEPS="[\"${LINES%???}\"]"
-    LINES=$(npm list --silent --depth=0 --production | grep @redhat-cloud-services -i | sed -E "s/^(.{0})(.{4})/\1/" | tr "\n" "," | sed -E "s/,/\",\"/g")
-    RH_CLOUD_SERVICES_DEPS="[\"${LINES%???}\"]"
+  if has_supported_lock_file; then
+    LINES=$(list_dependency_versions "@patternfly")
+    PATTERNFLY_DEPS=$(format_dependency_array "$LINES")
+
+    LINES=$(list_dependency_versions "@redhat-cloud-services")
+    RH_CLOUD_SERVICES_DEPS=$(format_dependency_array "$LINES")
   else
     PATTERNFLY_DEPS="[]"
     RH_CLOUD_SERVICES_DEPS="[]"

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help install test test-caddy test-env test-fs test-verbose lint lint-sh clean
 
 # Shell scripts to lint (active build scripts only; legacy src/ scripts excluded)
-SHELL_SCRIPTS := ../build_app_info.sh ../server_config_gen.sh ../universal_build.sh ../parse-secrets.sh
+SHELL_SCRIPTS := ../build_app_info.sh ../server_config_gen.sh ../universal_build.sh ../dependency_helpers.sh ../parse-secrets.sh
 
 help:
 	@echo "Available targets:"
@@ -41,8 +41,10 @@ lint-sh:
 
 clean:
 	-podman rm -f test-frontend-container test-envs-container test-fs-container
-	-podman rmi -f test-frontend-builder:test test-frontend-builder-envs:test test-frontend-builder-fs:test
+	-podman rmi -f test-frontend-builder:test test-frontend-builder-envs:test test-frontend-builder-fs:test test-frontend-builder-fs-pnpm:test
 	-rm -rf test-fixtures/fake-app/build-tools
+	-rm -rf test-fixtures/fake-pnpm-app/build-tools
 	-rm -rf test-fixtures/fake-app/dist
+	-rm -rf test-fixtures/fake-pnpm-app/dist
 	-find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 	-find . -type d -name .pytest_cache -exec rm -rf {} + 2>/dev/null || true

--- a/test/README.md
+++ b/test/README.md
@@ -43,6 +43,11 @@ test/
         └── build-tools/           # (Created dynamically during tests)
             ├── Dockerfile         # (Copied from repo root)
             └── *.sh               # (Build scripts copied from repo root)
+    └── fake-pnpm-app/             # Minimal pnpm test application
+        ├── package.json
+        ├── pnpm-lock.yaml
+        ├── build.js
+        └── LICENSE
 ```
 
 ## Prerequisites
@@ -132,8 +137,8 @@ pytest test_dockerfile_caddy.py --cov --cov-report=html
 1. Changes to `test-fixtures/fake-app` directory
 2. Runs `podman build -f build-tools/Dockerfile .` (mimicking real-world usage)
 3. The build process inside the container:
-   - Installs npm dependencies
-   - Runs `npm run build` (which executes `build.js`)
+   - Installs npm, yarn, or pnpm dependencies based on the lock file
+   - Runs the configured build script (which executes `build.js` in the fixtures)
    - Creates `dist/` directory with test assets (HTML, CSS, JS, JSON)
    - Runs build scripts to generate Caddyfile and app.info.json
    - Copies files to final Caddy-based image
@@ -172,6 +177,7 @@ After all tests complete:
 - ✓ `ENABLE_SENTRY` - Sentry configuration during build
 - ✓ `SENTRY_RELEASE` - Sentry release version
 - ✓ `USES_YARN` - Build system selection (npm vs yarn)
+- ✓ pnpm lockfile detection with `NPM_BUILD_SCRIPT` compatibility
 
 **Runtime ENV variables:**
 - ✓ `ENV_PUBLIC_PATH` - Custom Caddy route for serving app
@@ -179,7 +185,7 @@ After all tests complete:
 - ✓ Runtime variable override of defaults
 - ✓ Default values are correctly set
 
-**Note:** Due to the multi-stage Docker build, variables set in the builder stage (like `ENABLE_SENTRY`, `USES_YARN`, `YARN_BUILD_SCRIPT`) are only available during build and not at runtime in the final Caddy container. Only variables set in the final stage (`ENV_PUBLIC_PATH`, `CADDY_TLS_MODE`) are available at runtime.
+**Note:** Due to the multi-stage Docker build, variables set in the builder stage (like `ENABLE_SENTRY`, `USES_YARN`, `YARN_BUILD_SCRIPT`, `PNPM_BUILD_SCRIPT`) are only available during build and not at runtime in the final Caddy container. Only variables set in the final stage (`ENV_PUBLIC_PATH`, `CADDY_TLS_MODE`) are available at runtime.
 
 ### Filesystem Structure Tests (`test_dockerfile_filesystem.py`)
 
@@ -220,7 +226,7 @@ To test with a different application structure:
 1. Create a new directory under `test-fixtures/`
 2. Ensure it has the required files:
    - `package.json` with `insights.appname`
-   - `package-lock.json` or `yarn.lock`
+   - `package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`
    - Build script that creates a `dist/` directory
    - `LICENSE` file
    - Git repository initialized (required by build scripts)

--- a/test/test-fixtures/fake-pnpm-app/.gitignore
+++ b/test/test-fixtures/fake-pnpm-app/.gitignore
@@ -1,0 +1,2 @@
+build-tools/
+dist/

--- a/test/test-fixtures/fake-pnpm-app/LICENSE
+++ b/test/test-fixtures/fake-pnpm-app/LICENSE
@@ -1,0 +1,3 @@
+MIT License
+
+Test license for pnpm fixture.

--- a/test/test-fixtures/fake-pnpm-app/build.js
+++ b/test/test-fixtures/fake-pnpm-app/build.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const buildDir = process.env.APP_BUILD_DIR || 'dist';
+
+fs.mkdirSync(path.join(buildDir, 'css'), { recursive: true });
+fs.mkdirSync(path.join(buildDir, 'js'), { recursive: true });
+
+fs.writeFileSync(
+  path.join(buildDir, 'index.html'),
+  '<!DOCTYPE html><html><head><title>Test PNPM App</title></head><body><h1>Test PNPM App</h1></body></html>'
+);
+fs.writeFileSync(path.join(buildDir, 'css', 'app.css'), 'body { margin: 0; padding: 0; }');
+fs.writeFileSync(path.join(buildDir, 'js', 'app.js'), 'console.log("Test pnpm app loaded");');
+fs.writeFileSync(
+  path.join(buildDir, 'manifest.json'),
+  JSON.stringify({ name: 'test-pnpm-app', version: '1.0.0' }, null, 2)
+);
+
+if (process.env.BUILD_VARIANT === 'plugin') {
+  fs.writeFileSync(path.join(buildDir, 'plugin-build.txt'), 'plugin build');
+}
+
+console.log(`Build complete! Files created in ${buildDir}/`);

--- a/test/test-fixtures/fake-pnpm-app/package.json
+++ b/test/test-fixtures/fake-pnpm-app/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "test-pnpm-app",
+  "version": "1.0.0",
+  "description": "Fake pnpm app for testing Dockerfile",
+  "engines": {
+    "node": ">=16.0.0"
+  },
+  "scripts": {
+    "build-plugin": "BUILD_VARIANT=plugin node build.js"
+  },
+  "insights": {
+    "appname": "test-pnpm-app"
+  },
+  "dependencies": {}
+}

--- a/test/test-fixtures/fake-pnpm-app/pnpm-lock.yaml
+++ b/test/test-fixtures/fake-pnpm-app/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/test/test_dockerfile_caddy.py
+++ b/test/test_dockerfile_caddy.py
@@ -56,6 +56,7 @@ class TestDockerfileCaddy:
             "universal_build.sh",
             "build_app_info.sh",
             "server_config_gen.sh",
+            "dependency_helpers.sh",
             "parse-secrets.sh"
         ]
         for script in scripts:

--- a/test/test_dockerfile_env_vars.py
+++ b/test/test_dockerfile_env_vars.py
@@ -49,6 +49,7 @@ class TestDockerfileEnvVars:
             "universal_build.sh",
             "build_app_info.sh",
             "server_config_gen.sh",
+            "dependency_helpers.sh",
             "parse-secrets.sh"
         ]
         for script in scripts:
@@ -266,7 +267,8 @@ class TestDockerfileEnvVars:
     def test_build_args_accepted(self):
         """Test that various build-time arguments are accepted and don't break the build.
 
-        Tests multiple build args: ENABLE_SENTRY, SENTRY_RELEASE, and USES_YARN.
+        Tests multiple build args: ENABLE_SENTRY, SENTRY_RELEASE, USES_YARN, and
+        PNPM_BUILD_SCRIPT.
 
         Note: These variables are only available in the builder stage,
         not in the final runtime container due to multi-stage build.
@@ -281,14 +283,18 @@ class TestDockerfileEnvVars:
             # Prepare environment
             self._prepare_test_env(test_dir, repo_root)
 
-            # Build with multiple build args: Sentry + USES_YARN
+            # Build with multiple build args: Sentry + package manager args
             build_args = {
                 "ENABLE_SENTRY": "true",
                 "SENTRY_RELEASE": "test-release-123",
-                "USES_YARN": "false"
+                "USES_YARN": "false",
+                "PNPM_BUILD_SCRIPT": "build-plugin",
             }
 
-            print("Building with multiple build args: ENABLE_SENTRY, SENTRY_RELEASE, USES_YARN")
+            print(
+                "Building with multiple build args: ENABLE_SENTRY, SENTRY_RELEASE, "
+                "USES_YARN, PNPM_BUILD_SCRIPT"
+            )
             result = self._build_image(test_dir, build_args)
 
             # Verify the build completed successfully
@@ -299,6 +305,7 @@ class TestDockerfileEnvVars:
             print("  - ENABLE_SENTRY=true")
             print("  - SENTRY_RELEASE=test-release-123")
             print("  - USES_YARN=false")
+            print("  - PNPM_BUILD_SCRIPT=build-plugin")
             print("  (Note: Build-time vars are not available at runtime)")
 
         finally:

--- a/test/test_dockerfile_filesystem.py
+++ b/test/test_dockerfile_filesystem.py
@@ -83,6 +83,7 @@ class TestDockerfileFilesystem:
             "universal_build.sh",
             "build_app_info.sh",
             "server_config_gen.sh",
+            "dependency_helpers.sh",
             "parse-secrets.sh"
         ]
         for script in scripts:
@@ -521,6 +522,112 @@ class TestDockerfileFilesystem:
                 capture_output=True
             )
             print(f"✓ Cleaned up custom image {custom_image_name}")
+
+    def test_pnpm_lockfile_build_with_npm_build_script(self):
+        """Test pnpm lockfile detection with the existing NPM_BUILD_SCRIPT arg."""
+        print("\n=== Testing pnpm lockfile build with NPM_BUILD_SCRIPT ===")
+
+        test_script_dir = os.path.dirname(__file__)
+        repo_root = os.path.abspath(os.path.join(test_script_dir, ".."))
+        test_dir = os.path.join(test_script_dir, "test-fixtures", "fake-pnpm-app")
+        pnpm_image_name = "test-frontend-builder-fs-pnpm:test"
+
+        try:
+            self._prepare_test_env(test_dir, repo_root)
+
+            self._build_image(
+                test_dir,
+                build_args={"NPM_BUILD_SCRIPT": "build-plugin"},
+                image_name=pnpm_image_name,
+            )
+
+            index_exists = self._file_exists_in_image(
+                "/srv/dist/index.html",
+                image_name=pnpm_image_name,
+            )
+            assert index_exists, "pnpm build did not create /srv/dist/index.html"
+
+            plugin_marker_exists = self._file_exists_in_image(
+                "/srv/dist/plugin-build.txt",
+                image_name=pnpm_image_name,
+            )
+            assert plugin_marker_exists, "NPM_BUILD_SCRIPT=build-plugin was not used"
+
+            app_info_content = self._read_file_from_image(
+                "/srv/dist/app.info.json",
+                image_name=pnpm_image_name,
+            )
+            assert app_info_content is not None, "app.info.json was not generated"
+
+            app_info = json.loads(app_info_content)
+            assert app_info["app_name"] == "test-pnpm-app", (
+                f"Expected app_name 'test-pnpm-app', got '{app_info['app_name']}'"
+            )
+
+            print("✓ pnpm build completed and used NPM_BUILD_SCRIPT")
+
+        finally:
+            subprocess.run(
+                ["podman", "rmi", "-f", pnpm_image_name],
+                capture_output=True,
+            )
+            self._cleanup_test_env(test_dir)
+            print(f"✓ Cleaned up pnpm image {pnpm_image_name}")
+
+    def test_multiple_lockfiles_fail_build(self):
+        """Test package manager detection fails when conflicting lockfiles exist."""
+        print("\n=== Testing conflicting lockfile detection ===")
+
+        test_script_dir = os.path.dirname(__file__)
+        repo_root = os.path.abspath(os.path.join(test_script_dir, ".."))
+        test_dir = os.path.join(test_script_dir, "test-fixtures", "fake-pnpm-app")
+        conflict_image_name = "test-frontend-builder-fs-conflict:test"
+        package_lock_src = os.path.join(
+            test_script_dir,
+            "test-fixtures",
+            "fake-app",
+            "package-lock.json",
+        )
+        package_lock_dest = os.path.join(test_dir, "package-lock.json")
+
+        try:
+            self._prepare_test_env(test_dir, repo_root)
+            shutil.copy(package_lock_src, package_lock_dest)
+
+            result = subprocess.run(
+                [
+                    "podman",
+                    "build",
+                    "-t",
+                    conflict_image_name,
+                    "-f",
+                    "build-tools/Dockerfile",
+                    ".",
+                ],
+                cwd=test_dir,
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+
+            assert result.returncode != 0, "Build succeeded with multiple lockfiles"
+
+            output = f"{result.stdout}\n{result.stderr}"
+            assert "multiple supported package lock files found" in output
+            assert "package-lock.json" in output
+            assert "pnpm-lock.yaml" in output
+
+            print("✓ Build failed with a clear conflicting lockfile message")
+
+        finally:
+            if os.path.exists(package_lock_dest):
+                os.remove(package_lock_dest)
+            subprocess.run(
+                ["podman", "rmi", "-f", conflict_image_name],
+                capture_output=True,
+            )
+            self._cleanup_test_env(test_dir)
+            print(f"✓ Cleaned up conflict image {conflict_image_name}")
 
 
 if __name__ == "__main__":

--- a/universal_build.sh
+++ b/universal_build.sh
@@ -15,6 +15,7 @@ APP_NAME_FOR_SECRET="$(jq -r '.insights.appname' < "${PACKAGE_JSON_PATH:-package
 SECRET_VAR_NAME="${APP_NAME_FOR_SECRET}_SECRET"
 USES_NPM=false
 USES_YARN=false
+USES_PNPM=false
 
 # Disable verbose output to hide Sentry token from logs
 { old_opts=$(set +o); set +x; } 2>/dev/null
@@ -38,10 +39,12 @@ export APP_BUILD_DIR=${APP_BUILD_DIR:-dist}
 export OUTPUT_DIR=${OUTPUT_DIR:-dist}
 
 function install() {
-  if [ $USES_NPM == true ]; then
+  if [[ "$USES_NPM" == true ]]; then
     npm ci
-  elif [ $USES_YARN == true ]; then
+  elif [[ "$USES_YARN" == true ]]; then
     yarn install --immutable
+  elif [[ "$USES_PNPM" == true ]]; then
+    pnpm install --frozen-lockfile
   else
     # Normally we would not use exit in a source'd file, but this should fail the job
     echo "Exiting; no supported installation packages"
@@ -50,10 +53,12 @@ function install() {
 }
 
 function verify() {
-  if [ $USES_NPM == true ]; then
+  if [[ "$USES_NPM" == true ]]; then
     npm run verify
-  elif [ $USES_YARN == true ]; then
+  elif [[ "$USES_YARN" == true ]]; then
     yarn verify
+  elif [[ "$USES_PNPM" == true ]]; then
+    pnpm run verify
   else
     # Normally we would not use exit in a source'd file, but this should fail the job
     echo "Exiting; no supported verification tool or target"
@@ -78,6 +83,16 @@ function build() {
     else
       yarn build:prod
     fi
+  elif [[ "$USES_PNPM" == true ]]; then
+    # Prefer the pnpm-specific build arg, but keep NPM_BUILD_SCRIPT working for
+    # existing Tekton/Konflux configs that use that build arg name.
+    if [[ -n "$PNPM_BUILD_SCRIPT" ]]; then
+      pnpm run "$PNPM_BUILD_SCRIPT"
+    elif [[ -n "$NPM_BUILD_SCRIPT" ]]; then
+      pnpm run "$NPM_BUILD_SCRIPT"
+    else
+      pnpm run build
+    fi
   else
     # Normally we would not use exit in a source'd file, but this should fail the job
     echo "Exiting; no supported build or target"
@@ -93,25 +108,46 @@ function delete_node_modules() {
   fi
 }
 
-function setNpmOrYarn() {
-  # We can't assume npm or yarn, so we turn on the toggle depending on files in the root
-  if [[ -f package-lock.json ]]; then
-    USES_NPM=true
-  elif [[ -f yarn.lock ]]; then
-    USES_YARN=true
-  else
-  # Normally we would not use exit in a source'd file, but this should fail the job
-    echo "Exiting; no yarn or npm package lock files found. Add a package-lock.json or yarn.lock to your project root"
+function setPackageManager() {
+  # We can't assume npm, yarn, or pnpm, so we turn on the toggle depending on
+  # lock files in the root.
+  local lock_files=()
+
+  [[ -f package-lock.json ]] && lock_files+=("package-lock.json")
+  [[ -f yarn.lock ]] && lock_files+=("yarn.lock")
+  [[ -f pnpm-lock.yaml ]] && lock_files+=("pnpm-lock.yaml")
+
+  if (( ${#lock_files[@]} > 1 )); then
+    echo "Exiting; multiple supported package lock files found: ${lock_files[*]}. Keep only one of package-lock.json, yarn.lock, or pnpm-lock.yaml in your project root" >&2
     exit 1
   fi
+
+  if (( ${#lock_files[@]} == 0 )); then
+    # Normally we would not use exit in a source'd file, but this should fail the job
+    echo "Exiting; no supported package lock files found. Add package-lock.json, yarn.lock, or pnpm-lock.yaml to your project root" >&2
+    exit 1
+  fi
+
+  USES_NPM=false
+  USES_YARN=false
+  USES_PNPM=false
+
+  case "${lock_files[0]}" in
+    package-lock.json)
+      USES_NPM=true
+      ;;
+    yarn.lock)
+      USES_YARN=true
+      ;;
+    pnpm-lock.yaml)
+      USES_PNPM=true
+      ;;
+  esac
 }
 
 get_appname_from_package() {
   jq --raw-output '.insights.appname' < "${PACKAGE_JSON_PATH}"
 }
-
-# Work around large package timeout; up default from 30s to 5m
-yarn config set network-timeout 300000
 
 if ! APP_NAME=$(get_appname_from_package); then
   echo "could not read application name from package.json"
@@ -120,7 +156,12 @@ fi
 
 export APP_NAME
 
-setNpmOrYarn
+setPackageManager
+
+if [[ "$USES_YARN" == true ]]; then
+  # Work around large package timeout; up default from 30s to 5m
+  yarn config set network-timeout 300000
+fi
 
 install
 


### PR DESCRIPTION
## Summary

Adds pnpm support to the shared frontend Dockerfile build path so consumers with `pnpm-lock.yaml` can build without `package-lock.json` or `yarn.lock`.

Closes #357.
Blocks quay/quay#6442.

## Changes

- Detect `pnpm-lock.yaml` in `universal_build.sh`.
- Install pnpm in the builder image and run `pnpm install --frozen-lockfile`.
- Run pnpm builds with `PNPM_BUILD_SCRIPT`, while preserving `NPM_BUILD_SCRIPT` compatibility for existing Konflux pipeline configs.
- Update dependency metadata helpers to collect direct dependency versions for npm/yarn/pnpm projects.
- Add a fake pnpm app fixture and filesystem test coverage for the Dockerfile build path.
- Update build/test docs to include pnpm as a supported package manager.

## Verification

- `bash -n universal_build.sh build_app_info.sh server_config_gen.sh`
- `test/.venv/bin/ruff check .`
- `test/.venv/bin/shellcheck ../build_app_info.sh ../server_config_gen.sh ../universal_build.sh ../parse-secrets.sh`
- `GIT_CONFIG_GLOBAL=/tmp/build-tools-test-gitconfig test/.venv/bin/pytest test_dockerfile_filesystem.py::TestDockerfileFilesystem::test_pnpm_lockfile_build_with_npm_build_script -v -s`

## Notes

The targeted pytest uses a temporary external Git config to disable commit signing for fixture setup in this local environment. No test-helper signing changes are included in this PR.
