### PR TITLE
[RHINENG-21816] Replace build-container-additional-secret with sentry-secrets to migrate to external secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN chmod +x build-tools/parse-secrets.sh
 
 # 👉 Mount one secret with many keys; universal_build.sh handles the rest
 USER root
-RUN --mount=type=secret,id=build-container-additional-secret/secrets,required=false \
+RUN --mount=type=secret,id=sentry-secrets/secrets,required=false \
   universal_build.sh
 USER default
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ INVENTORY_SECRET=your-secret-value
 ```
 
 **Key features:**
-- Secrets are mounted at `/run/secrets/build-container-additional-secret/secrets`
-- You have to name your secret as `build-container-additional-secret` inside of it create a single key/value secret with key as `secrets` and value contents of your `.env` file
+- Secrets are mounted at `/run/secrets/sentry-secrets/secrets`
+- You have to name your secret as `sentry-secrets` inside of it create a single key/value secret with key as `secrets` and value contents of your `.env` file
 - The `parse-secrets.sh` script automatically parses the `.env` file format
 - Comments (lines starting with `#`) and empty lines are ignored
 - All key-value pairs are exported as environment variables during the build

--- a/docs/build-script-guidelines.md
+++ b/docs/build-script-guidelines.md
@@ -84,7 +84,7 @@ Follow this same fallback pattern when adding new git-derived metadata.
 
 ### Secret Handling
 
-The `parse-secrets.sh` script reads from a fixed path (`/run/secrets/build-container-additional-secret/secrets`). Rules:
+The `parse-secrets.sh` script reads from a fixed path (`/run/secrets/sentry-secrets/secrets`). Rules:
 
 - Never echo secret values to stdout
 - Handle missing secret files gracefully (exit 0, not 1)

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -177,7 +177,7 @@ with tempfile.NamedTemporaryFile(mode='w', suffix='.env', delete=False) as f:
 # Build with secret mount
 subprocess.run(
     ["podman", "build", "--secret",
-     f"id=build-container-additional-secret/secrets,src={secret_path}",
+     f"id=sentry-secrets/secrets,src={secret_path}",
      "-f", "build-tools/Dockerfile", "-t", "test-secrets:test", "."],
     cwd=str(self.FIXTURE_DIR),
     check=True,

--- a/parse-secrets.sh
+++ b/parse-secrets.sh
@@ -7,7 +7,7 @@
 # Disable bash xtrace so secret values are not printed in CI logs, then restore
 { old_opts=$(set +o); set +x; } 2>/dev/null
 
-SECRETS_FILE="/run/secrets/build-container-additional-secret/secrets"
+SECRETS_FILE="/run/secrets/sentry-secrets/secrets"
 
 if [ ! -f "$SECRETS_FILE" ]; then
     echo "Error: Secrets file not found at $SECRETS_FILE"
@@ -23,16 +23,16 @@ else
             if [[ -z "$line" ]] || [[ "$line" =~ ^[[:space:]]*# ]]; then
                 continue
             fi
-            
+
             # Check if line contains = and split into key=value
             if [[ "$line" =~ ^[^=]+= ]]; then
                 # Extract key and value
                 key="${line%%=*}"
                 value="${line#*=}"
-                
+
                 # Remove any leading/trailing whitespace from key
                 key=$(echo "$key" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-                
+
                 if [[ -n "$key" ]]; then
                     export "$key"="$value"
                     echo "Set environment variable: $key"


### PR DESCRIPTION

### Description
<!-- Summary of proposed changes: what and why. -->
<!-- Which downstream repos/teams are affected? -->
This is continuation of closed PR:
https://github.com/RedHatInsights/insights-frontend-builder-common/pull/282

I reconsidered how the secrets should be stored/exposed and it is probably better to have them all in one place (not per app).
We need migrate to external secrets instead of using secret stored in Konflux cluster.

Current stored secret contains just sentry entries and that is why I renamed the secret path here.

See also MR 20330 in konflux release data repo.


---

### Blast radius
<!-- Who/what consumes this? List affected repos, services, or pipelines. -->
<!-- How was this tested against consumers? -->

---

### Rollback plan
<!-- If this breaks production, how do we revert? -->
<!-- Is git revert sufficient, or are there additional steps? -->

- revert this PR and build new image
---

### Checklist
- [ ] Tested against at least one consuming repo/service
- [ ] No breaking changes to existing consumers (or migration path documented)
- [ ] No hardcoded secrets, tokens, or passwords
- [ ] Container images pinned to specific tags, not `latest`

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->
