### PR TITLE
chore(RHCLOUD-50111): bump builder base image to ubi10/nodejs-24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@
 #   Node 24: --build-arg NODE_BUILD_VERSION=24 --build-arg NODE_IMAGE_TAG=<appropriate-tag>
 #
 # To find available tags, visit:
-# https://catalog.redhat.com/software/containers/ubi9/nodejs-22/62e8e7ed22d1d3c2dfe2ca01
-ARG NODE_BUILD_VERSION=22
-ARG NODE_IMAGE_TAG=9.8-1780375952
-FROM registry.access.redhat.com/ubi9/nodejs-${NODE_BUILD_VERSION}:${NODE_IMAGE_TAG} as builder
+# https://catalog.redhat.com/en/software/containers/ubi10/nodejs-24/67f6288d9700d2bde865192a
+ARG NODE_BUILD_VERSION=24
+ARG NODE_IMAGE_TAG=10.2-1785835781
+FROM registry.access.redhat.com/ubi10/nodejs-${NODE_BUILD_VERSION}:${NODE_IMAGE_TAG} as builder
 
 USER root
 

--- a/Dockerfile.hermetic
+++ b/Dockerfile.hermetic
@@ -11,10 +11,10 @@
 #   Node 24: --build-arg NODE_BUILD_VERSION=24 --build-arg NODE_IMAGE_TAG=<appropriate-tag>
 #
 # To find available tags, visit:
-# https://catalog.redhat.com/software/containers/ubi9/nodejs-22/62e8e7ed22d1d3c2dfe2ca01
-ARG NODE_BUILD_VERSION=22
-ARG NODE_IMAGE_TAG=9.8-1780375952
-FROM registry.access.redhat.com/ubi9/nodejs-${NODE_BUILD_VERSION}:${NODE_IMAGE_TAG} AS builder
+# https://catalog.redhat.com/en/software/containers/ubi10/nodejs-24/67f6288d9700d2bde865192a
+ARG NODE_BUILD_VERSION=24
+ARG NODE_IMAGE_TAG=10.2-1785835781
+FROM registry.access.redhat.com/ubi10/nodejs-${NODE_BUILD_VERSION}:${NODE_IMAGE_TAG} as builder
 
 # Additional arguments to be appended for `npm ci`, e.g. "--legacy-peer-deps"
 ARG NPM_CI_ARGS=
@@ -45,11 +45,11 @@ RUN npm run build
 
 # Stage 2: Semi-minimal runtime image - contains only built files and minimal dependencies for the RH certification
 
-# To achieve a hermetic build with minimal container size, you can request an exception for the image to use a base image 
+# To achieve a hermetic build with minimal container size, you can request an exception for the image to use a base image
 # other than ubi-minimal. This will allow you to use a smaller base image like scratch or alpine.
 
-# Alternatively, you can use the `docker-build-multi-platform-oci-ta` pipeline, which supports building multi-arch 
-# container images while maintaining trust after pipeline customization. This pipeline uses OCI artifacts instead of 
+# Alternatively, you can use the `docker-build-multi-platform-oci-ta` pipeline, which supports building multi-arch
+# container images while maintaining trust after pipeline customization. This pipeline uses OCI artifacts instead of
 #Persistent Volume Claims, which may help reduce the container size.
 
 # You can also take a look at the workarounds:supportRedHatImageVersion preset for other available options.
@@ -80,9 +80,9 @@ COPY --from=builder /opt/app-root/src/LICENSE /licenses/
 
 # Create srv directory and copy built files from builder stage
 RUN mkdir -p /srv
-COPY --from=builder /opt/app-root/src/dist /srv/dist 
-COPY --from=builder /opt/app-root/src/package.json /srv/package.json 
-COPY --from=builder /opt/app-root/src/package-lock.json /srv/package-lock.json 
+COPY --from=builder /opt/app-root/src/dist /srv/dist
+COPY --from=builder /opt/app-root/src/package.json /srv/package.json
+COPY --from=builder /opt/app-root/src/package-lock.json /srv/package-lock.json
 
 # Set to non-root user
 USER 1001


### PR DESCRIPTION
# Description

Bump base build image in Dockerfile and Dockerfile.hermetic from ubi9/nodejs-22:9.8-1780375952 to ubi10/nodejs-24:10.2-1785835781.

Root cause: consuming repos (e.g. insights-chrome) pin package.json engines.npm to >=10.9.8, but the old pinned base image only ships npm 10.9.7. This makes npm ci fail with EBADENGINE in Konflux PR builds. The build script has no set -e, so the failure doesn't stop the pipeline early — it cascades into a missing node_modules, a missing webpack binary, and downstream app.info.json / server_config_gen.sh failures before buildah finally exits 1.

New image ships node v24.18.0 / npm 11.16.0, clearing the engine floor and matching where consumers are already pinning .nvmrc (e.g. insights-chrome is on Node 24).

[RHCLOUD-50111](https://redhat.atlassian.net/browse/RHCLOUD-50111)

---
# Blast radius

Consumed by every repo that vendors this repo as the build-tools submodule (e.g. insights-chrome, and other HCC frontend repos using the same Konflux build pipeline). Any consumer whose package.json engines/toolchain assumes Node 22 could be affected by the Node 22→24 jump.

## Tested against insights-chrome:
- Populated a local insights-chrome/build-tools/ with this branch's Dockerfile
- Ran full podman build (no cache) end to end: npm ci succeeds (no EBADENGINE), npm run build (webpack) compiles clean, build_app_info.sh / server_config_gen.sh succeed, Caddy runtime stage builds and tags
- Ran the resulting image, confirmed Caddy serves / with 200 OK

Not yet tested against other consuming repos — flagging for review since Node 22→24 could surface issues elsewhere.

---
# Rollback plan

git revert is sufficient — this is a pinned tag bump with no schema/APthe new base image on their next build once their build-tools submodule pointer is bumped, so reverting here plus re-bumping submodule pointer

---
# Checklist

- [x] Tested against at least one consuming repo/service (insights-chrke test)
- [ ] No breaking changes to existing consumers (or migration path docnst insights-chrome; other consumers unverified
- [x] No hardcoded secrets, tokens, or passwords
- [x] Container images pinned to specific tags, not latest

AI disclosure

Assisted by: Claude Code

[RHCLOUD-50111]: https://redhat.atlassian.net/browse/RHCLOUD-50111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ